### PR TITLE
Changing hashing algorithm from md5 to sha256.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
+os:
+  - windows
+  - linux
+  - osx
 node_js:
-  - 'stable'
-  - 'lts/*'
-  - '10'
-  - '8'
+  - "node"
+  - 10
+  - 8
+  - 6
 before_install:
   - 'npm i -g npm@latest'
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,5 @@ node_js:
   - 10
   - 8
   - 6
-before_install:
-  - 'npm i -g npm@latest'
 after_script:
   - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
-const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const hasha = require('hasha');
 const makeDir = require('make-dir');
 const writeFileAtomic = require('write-file-atomic');
 const packageHash = require('package-hash');
@@ -64,12 +64,7 @@ function wrap(opts) {
 			data = data.concat(hashData(input, metadata));
 		}
 
-		const cryptoHash = crypto.createHash('sha256');
-		data.forEach(item => {
-			cryptoHash.update(item);
-		});
-
-		const hash = cryptoHash.digest('hex');
+		const hash = hasha(data, {algorithm: 'sha256'});
 		const cachedPath = path.join(cacheDir, hash + ext);
 
 		if (onHash) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const makeDir = require('make-dir');
-const md5Hex = require('md5-hex');
 const writeFileAtomic = require('write-file-atomic');
 const packageHash = require('package-hash');
 
@@ -64,7 +64,12 @@ function wrap(opts) {
 			data = data.concat(hashData(input, metadata));
 		}
 
-		const hash = md5Hex(data);
+		const cryptoHash = crypto.createHash('sha256');
+		data.forEach(item => {
+			cryptoHash.update(item);
+		});
+
+		const hash = cryptoHash.digest('hex');
 		const cachedPath = path.join(cacheDir, hash + ext);
 
 		if (onHash) {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function wrap(opts) {
 
 		try {
 			return fs.readFileSync(cachedPath, encoding);
-		} catch (err) {
+		} catch (error) {
 			const result = transform(input, metadata, hash);
 			writeFileAtomic.sync(cachedPath, result, {encoding});
 			return result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,18 +16,18 @@
 			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.8.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
-				"babel-plugin-transform-async-to-generator": "^6.16.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.19.0",
-				"babel-plugin-transform-es2015-function-name": "^6.9.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-				"babel-plugin-transform-es2015-parameters": "^6.21.0",
-				"babel-plugin-transform-es2015-spread": "^6.8.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.8.0",
-				"package-hash": "^1.2.0"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"package-hash": "1.2.0"
 			},
 			"dependencies": {
 				"md5-hex": {
@@ -36,7 +36,7 @@
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "^0.1.1"
+						"md5-o-matic": "0.1.1"
 					}
 				},
 				"package-hash": {
@@ -45,7 +45,7 @@
 					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
 					"dev": true,
 					"requires": {
-						"md5-hex": "^1.3.0"
+						"md5-hex": "1.3.0"
 					}
 				}
 			}
@@ -56,8 +56,8 @@
 			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
 			"dev": true,
 			"requires": {
-				"@ava/babel-plugin-throws-helper": "^2.0.0",
-				"babel-plugin-espower": "^2.3.2"
+				"@ava/babel-plugin-throws-helper": "2.0.0",
+				"babel-plugin-espower": "2.4.0"
 			}
 		},
 		"@ava/write-file-atomic": {
@@ -66,9 +66,9 @@
 			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"slide": "^1.1.5"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"slide": "1.1.6"
 			}
 		},
 		"@babel/code-frame": {
@@ -87,10 +87,10 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.49",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.5",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"jsesc": "2.5.1",
+				"lodash": "4.17.10",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -136,9 +136,9 @@
 			"integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"chalk": "2.4.1",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"@babel/parser": {
@@ -156,7 +156,7 @@
 				"@babel/code-frame": "7.0.0-beta.49",
 				"@babel/parser": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"lodash": "^4.17.5"
+				"lodash": "4.17.10"
 			}
 		},
 		"@babel/traverse": {
@@ -171,10 +171,10 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.49",
 				"@babel/parser": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.17.5"
+				"debug": "3.1.0",
+				"globals": "11.7.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.10"
 			},
 			"dependencies": {
 				"globals": {
@@ -191,9 +191,9 @@
 			"integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.5",
-				"to-fast-properties": "^2.0.0"
+				"esutils": "2.0.2",
+				"lodash": "4.17.10",
+				"to-fast-properties": "2.0.0"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -210,7 +210,7 @@
 			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1"
+				"arrify": "1.0.1"
 			}
 		},
 		"@ladjs/time-require": {
@@ -219,10 +219,10 @@
 			"integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^0.4.0",
-				"date-time": "^0.1.1",
-				"pretty-ms": "^0.2.1",
-				"text-table": "^0.2.0"
+				"chalk": "0.4.0",
+				"date-time": "0.1.1",
+				"pretty-ms": "0.2.2",
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -237,9 +237,9 @@
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
 					}
 				},
 				"pretty-ms": {
@@ -248,7 +248,7 @@
 					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
 					"dev": true,
 					"requires": {
-						"parse-ms": "^0.1.0"
+						"parse-ms": "0.1.2"
 					}
 				},
 				"strip-ansi": {
@@ -265,8 +265,8 @@
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
 			"dev": true,
 			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"glob-to-regexp": "^0.3.0"
+				"call-me-maybe": "1.0.1",
+				"glob-to-regexp": "0.3.0"
 			}
 		},
 		"@nodelib/fs.stat": {
@@ -296,7 +296,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "^3.0.4"
+				"acorn": "3.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -313,10 +313,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-keywords": {
@@ -331,7 +331,7 @@
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.0.0"
+				"string-width": "2.1.1"
 			}
 		},
 		"ansi-escapes": {
@@ -352,7 +352,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.2"
 			}
 		},
 		"anymatch": {
@@ -361,8 +361,8 @@
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^2.1.5",
-				"normalize-path": "^2.0.0"
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"argparse": {
@@ -371,7 +371,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -380,7 +380,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.0.1"
+				"arr-flatten": "1.1.0"
 			}
 		},
 		"arr-exclude": {
@@ -419,7 +419,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -488,89 +488,89 @@
 			"integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
 			"dev": true,
 			"requires": {
-				"@ava/babel-preset-stage-4": "^1.1.0",
-				"@ava/babel-preset-transform-test-files": "^3.0.0",
-				"@ava/write-file-atomic": "^2.2.0",
-				"@concordance/react": "^1.0.0",
-				"@ladjs/time-require": "^0.1.4",
-				"ansi-escapes": "^3.0.0",
-				"ansi-styles": "^3.1.0",
-				"arr-flatten": "^1.0.1",
-				"array-union": "^1.0.1",
-				"array-uniq": "^1.0.2",
-				"arrify": "^1.0.0",
-				"auto-bind": "^1.1.0",
-				"ava-init": "^0.2.0",
-				"babel-core": "^6.17.0",
-				"babel-generator": "^6.26.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"bluebird": "^3.0.0",
-				"caching-transform": "^1.0.0",
-				"chalk": "^2.0.1",
-				"chokidar": "^1.4.2",
-				"clean-stack": "^1.1.1",
-				"clean-yaml-object": "^0.1.0",
-				"cli-cursor": "^2.1.0",
-				"cli-spinners": "^1.0.0",
-				"cli-truncate": "^1.0.0",
-				"co-with-promise": "^4.6.0",
-				"code-excerpt": "^2.1.1",
-				"common-path-prefix": "^1.0.0",
-				"concordance": "^3.0.0",
-				"convert-source-map": "^1.5.1",
-				"core-assert": "^0.2.0",
-				"currently-unhandled": "^0.4.1",
-				"debug": "^3.0.1",
-				"dot-prop": "^4.1.0",
-				"empower-core": "^0.6.1",
-				"equal-length": "^1.0.0",
-				"figures": "^2.0.0",
-				"find-cache-dir": "^1.0.0",
-				"fn-name": "^2.0.0",
-				"get-port": "^3.0.0",
-				"globby": "^6.0.0",
-				"has-flag": "^2.0.0",
-				"hullabaloo-config-manager": "^1.1.0",
-				"ignore-by-default": "^1.0.0",
-				"import-local": "^0.1.1",
-				"indent-string": "^3.0.0",
-				"is-ci": "^1.0.7",
-				"is-generator-fn": "^1.0.0",
-				"is-obj": "^1.0.0",
-				"is-observable": "^1.0.0",
-				"is-promise": "^2.1.0",
-				"last-line-stream": "^1.0.0",
-				"lodash.clonedeepwith": "^4.5.0",
-				"lodash.debounce": "^4.0.3",
-				"lodash.difference": "^4.3.0",
-				"lodash.flatten": "^4.2.0",
-				"loud-rejection": "^1.2.0",
-				"make-dir": "^1.0.0",
-				"matcher": "^1.0.0",
-				"md5-hex": "^2.0.0",
-				"meow": "^3.7.0",
-				"ms": "^2.0.0",
-				"multimatch": "^2.1.0",
-				"observable-to-promise": "^0.5.0",
-				"option-chain": "^1.0.0",
-				"package-hash": "^2.0.0",
-				"pkg-conf": "^2.0.0",
-				"plur": "^2.0.0",
-				"pretty-ms": "^3.0.0",
-				"require-precompiled": "^0.1.0",
-				"resolve-cwd": "^2.0.0",
-				"safe-buffer": "^5.1.1",
-				"semver": "^5.4.1",
-				"slash": "^1.0.0",
-				"source-map-support": "^0.5.0",
-				"stack-utils": "^1.0.1",
-				"strip-ansi": "^4.0.0",
-				"strip-bom-buf": "^1.0.0",
-				"supertap": "^1.0.0",
-				"supports-color": "^5.0.0",
-				"trim-off-newlines": "^1.0.1",
-				"unique-temp-dir": "^1.0.0",
-				"update-notifier": "^2.3.0"
+				"@ava/babel-preset-stage-4": "1.1.0",
+				"@ava/babel-preset-transform-test-files": "3.0.0",
+				"@ava/write-file-atomic": "2.2.0",
+				"@concordance/react": "1.0.0",
+				"@ladjs/time-require": "0.1.4",
+				"ansi-escapes": "3.1.0",
+				"ansi-styles": "3.2.1",
+				"arr-flatten": "1.1.0",
+				"array-union": "1.0.2",
+				"array-uniq": "1.0.3",
+				"arrify": "1.0.1",
+				"auto-bind": "1.2.1",
+				"ava-init": "0.2.1",
+				"babel-core": "6.26.3",
+				"babel-generator": "6.26.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"bluebird": "3.5.1",
+				"caching-transform": "1.0.1",
+				"chalk": "2.4.1",
+				"chokidar": "1.7.0",
+				"clean-stack": "1.3.0",
+				"clean-yaml-object": "0.1.0",
+				"cli-cursor": "2.1.0",
+				"cli-spinners": "1.3.1",
+				"cli-truncate": "1.1.0",
+				"co-with-promise": "4.6.0",
+				"code-excerpt": "2.1.1",
+				"common-path-prefix": "1.0.0",
+				"concordance": "3.0.0",
+				"convert-source-map": "1.5.1",
+				"core-assert": "0.2.1",
+				"currently-unhandled": "0.4.1",
+				"debug": "3.1.0",
+				"dot-prop": "4.2.0",
+				"empower-core": "0.6.2",
+				"equal-length": "1.0.1",
+				"figures": "2.0.0",
+				"find-cache-dir": "1.0.0",
+				"fn-name": "2.0.1",
+				"get-port": "3.2.0",
+				"globby": "6.1.0",
+				"has-flag": "2.0.0",
+				"hullabaloo-config-manager": "1.1.1",
+				"ignore-by-default": "1.0.1",
+				"import-local": "0.1.1",
+				"indent-string": "3.2.0",
+				"is-ci": "1.1.0",
+				"is-generator-fn": "1.0.0",
+				"is-obj": "1.0.1",
+				"is-observable": "1.1.0",
+				"is-promise": "2.1.0",
+				"last-line-stream": "1.0.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.debounce": "4.0.8",
+				"lodash.difference": "4.5.0",
+				"lodash.flatten": "4.4.0",
+				"loud-rejection": "1.6.0",
+				"make-dir": "1.3.0",
+				"matcher": "1.1.1",
+				"md5-hex": "2.0.0",
+				"meow": "3.7.0",
+				"ms": "2.1.1",
+				"multimatch": "2.1.0",
+				"observable-to-promise": "0.5.0",
+				"option-chain": "1.0.0",
+				"package-hash": "2.0.0",
+				"pkg-conf": "2.1.0",
+				"plur": "2.1.2",
+				"pretty-ms": "3.2.0",
+				"require-precompiled": "0.1.0",
+				"resolve-cwd": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"semver": "5.5.0",
+				"slash": "1.0.0",
+				"source-map-support": "0.5.6",
+				"stack-utils": "1.0.1",
+				"strip-ansi": "4.0.0",
+				"strip-bom-buf": "1.0.0",
+				"supertap": "1.0.0",
+				"supports-color": "5.4.0",
+				"trim-off-newlines": "1.0.1",
+				"unique-temp-dir": "1.0.0",
+				"update-notifier": "2.5.0"
 			}
 		},
 		"ava-init": {
@@ -579,11 +579,11 @@
 			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
 			"dev": true,
 			"requires": {
-				"arr-exclude": "^1.0.0",
-				"execa": "^0.7.0",
-				"has-yarn": "^1.0.0",
-				"read-pkg-up": "^2.0.0",
-				"write-pkg": "^3.1.0"
+				"arr-exclude": "1.0.0",
+				"execa": "0.7.0",
+				"has-yarn": "1.0.0",
+				"read-pkg-up": "2.0.0",
+				"write-pkg": "3.2.0"
 			}
 		},
 		"aws-sign2": {
@@ -604,9 +604,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -621,11 +621,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -634,7 +634,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"supports-color": {
@@ -651,25 +651,25 @@
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -695,14 +695,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.10",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -719,9 +719,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -730,10 +730,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -742,9 +742,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -753,11 +753,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -766,8 +766,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -776,8 +776,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -786,9 +786,9 @@
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -797,11 +797,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -810,8 +810,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-messages": {
@@ -820,7 +820,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -829,7 +829,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-espower": {
@@ -838,13 +838,13 @@
 			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.1.0",
-				"babylon": "^6.1.0",
-				"call-matcher": "^1.0.0",
-				"core-js": "^2.0.0",
-				"espower-location-detector": "^1.0.0",
-				"espurify": "^1.6.0",
-				"estraverse": "^4.1.1"
+				"babel-generator": "6.26.1",
+				"babylon": "6.18.0",
+				"call-matcher": "1.0.1",
+				"core-js": "2.5.7",
+				"espower-location-detector": "1.0.0",
+				"espurify": "1.8.0",
+				"estraverse": "4.2.0"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -877,9 +877,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -888,7 +888,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -897,9 +897,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -908,10 +908,10 @@
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -920,12 +920,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -934,7 +934,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -943,9 +943,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -954,9 +954,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -965,9 +965,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -976,8 +976,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-register": {
@@ -986,13 +986,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.3",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.7",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.10",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			},
 			"dependencies": {
 				"source-map-support": {
@@ -1001,7 +1001,7 @@
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
-						"source-map": "^0.5.6"
+						"source-map": "0.5.7"
 					}
 				}
 			}
@@ -1012,8 +1012,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.7",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"babel-template": {
@@ -1022,11 +1022,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-traverse": {
@@ -1035,15 +1035,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.10"
 			},
 			"dependencies": {
 				"debug": {
@@ -1069,10 +1069,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.10",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -1093,13 +1093,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1108,7 +1108,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1117,7 +1117,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1126,7 +1126,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1135,9 +1135,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -1161,7 +1161,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"binary-extensions": {
@@ -1182,13 +1182,13 @@
 			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 			"dev": true,
 			"requires": {
-				"ansi-align": "^2.0.0",
-				"camelcase": "^4.0.0",
-				"chalk": "^2.0.1",
-				"cli-boxes": "^1.0.0",
-				"string-width": "^2.0.0",
-				"term-size": "^1.2.0",
-				"widest-line": "^2.0.0"
+				"ansi-align": "2.0.0",
+				"camelcase": "4.1.0",
+				"chalk": "2.4.1",
+				"cli-boxes": "1.0.0",
+				"string-width": "2.1.1",
+				"term-size": "1.2.0",
+				"widest-line": "2.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -1205,7 +1205,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1215,9 +1215,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
 			}
 		},
 		"buf-compare": {
@@ -1244,15 +1244,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -1269,9 +1269,9 @@
 			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
 			"dev": true,
 			"requires": {
-				"md5-hex": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"write-file-atomic": "^1.1.4"
+				"md5-hex": "1.3.0",
+				"mkdirp": "0.5.1",
+				"write-file-atomic": "1.3.4"
 			},
 			"dependencies": {
 				"md5-hex": {
@@ -1280,7 +1280,7 @@
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "^0.1.1"
+						"md5-o-matic": "0.1.1"
 					}
 				},
 				"write-file-atomic": {
@@ -1289,9 +1289,9 @@
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
 					}
 				}
 			}
@@ -1302,10 +1302,10 @@
 			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.0.0",
-				"deep-equal": "^1.0.0",
-				"espurify": "^1.6.0",
-				"estraverse": "^4.0.0"
+				"core-js": "2.5.7",
+				"deep-equal": "1.0.1",
+				"espurify": "1.8.0",
+				"estraverse": "4.2.0"
 			}
 		},
 		"call-me-maybe": {
@@ -1326,7 +1326,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			}
 		},
 		"callsites": {
@@ -1347,8 +1347,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
 			}
 		},
 		"capture-stack-trace": {
@@ -1369,9 +1369,9 @@
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.4.0"
 			}
 		},
 		"chardet": {
@@ -1386,15 +1386,15 @@
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"dev": true,
 			"requires": {
-				"anymatch": "^1.3.0",
-				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
-				"glob-parent": "^2.0.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^2.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0"
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.2.4",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
 			}
 		},
 		"ci-info": {
@@ -1415,10 +1415,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1427,7 +1427,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"isobject": {
@@ -1444,7 +1444,7 @@
 			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"clean-stack": {
@@ -1471,7 +1471,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -1486,8 +1486,8 @@
 			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
 			"dev": true,
 			"requires": {
-				"slice-ansi": "^1.0.0",
-				"string-width": "^2.0.0"
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
 			}
 		},
 		"cli-width": {
@@ -1508,7 +1508,7 @@
 			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
 			"dev": true,
 			"requires": {
-				"pinkie-promise": "^1.0.0"
+				"pinkie-promise": "1.0.0"
 			}
 		},
 		"code-excerpt": {
@@ -1517,7 +1517,7 @@
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
 			"dev": true,
 			"requires": {
-				"convert-to-spaces": "^1.0.1"
+				"convert-to-spaces": "1.0.2"
 			}
 		},
 		"collection-visit": {
@@ -1526,8 +1526,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color-convert": {
@@ -1551,7 +1551,7 @@
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"common-path-prefix": {
@@ -1584,10 +1584,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"buffer-from": "1.1.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"typedarray": "0.0.6"
 			}
 		},
 		"concordance": {
@@ -1596,17 +1596,17 @@
 			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
 			"dev": true,
 			"requires": {
-				"date-time": "^2.1.0",
-				"esutils": "^2.0.2",
-				"fast-diff": "^1.1.1",
-				"function-name-support": "^0.2.0",
-				"js-string-escape": "^1.0.1",
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.flattendeep": "^4.4.0",
-				"lodash.merge": "^4.6.0",
-				"md5-hex": "^2.0.0",
-				"semver": "^5.3.0",
-				"well-known-symbols": "^1.0.0"
+				"date-time": "2.1.0",
+				"esutils": "2.0.2",
+				"fast-diff": "1.1.2",
+				"function-name-support": "0.2.0",
+				"js-string-escape": "1.0.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.flattendeep": "4.4.0",
+				"lodash.merge": "4.6.1",
+				"md5-hex": "2.0.0",
+				"semver": "5.5.0",
+				"well-known-symbols": "1.0.0"
 			},
 			"dependencies": {
 				"date-time": {
@@ -1615,7 +1615,7 @@
 					"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
 					"dev": true,
 					"requires": {
-						"time-zone": "^1.0.0"
+						"time-zone": "1.0.0"
 					}
 				}
 			}
@@ -1626,12 +1626,12 @@
 			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "^4.1.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^1.0.0",
-				"unique-string": "^1.0.0",
-				"write-file-atomic": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
+				"dot-prop": "4.2.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.3.0",
+				"unique-string": "1.0.0",
+				"write-file-atomic": "2.3.0",
+				"xdg-basedir": "3.0.0"
 			}
 		},
 		"contains-path": {
@@ -1664,8 +1664,8 @@
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
 			"dev": true,
 			"requires": {
-				"buf-compare": "^1.0.0",
-				"is-error": "^2.2.0"
+				"buf-compare": "1.0.1",
+				"is-error": "2.2.1"
 			}
 		},
 		"core-js": {
@@ -1686,11 +1686,11 @@
 			"integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
 			"dev": true,
 			"requires": {
-				"js-yaml": "^3.6.1",
-				"lcov-parse": "^0.0.10",
-				"log-driver": "^1.2.5",
-				"minimist": "^1.2.0",
-				"request": "^2.79.0"
+				"js-yaml": "3.12.0",
+				"lcov-parse": "0.0.10",
+				"log-driver": "1.2.7",
+				"minimist": "1.2.0",
+				"request": "2.87.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -1707,7 +1707,7 @@
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"dev": true,
 			"requires": {
-				"capture-stack-trace": "^1.0.0"
+				"capture-stack-trace": "1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -1716,9 +1716,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.3",
+				"shebang-command": "1.2.0",
+				"which": "1.3.1"
 			}
 		},
 		"crypto-random-string": {
@@ -1733,7 +1733,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"dashdash": {
@@ -1742,7 +1742,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"date-time": {
@@ -1780,8 +1780,8 @@
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
+				"decamelize": "1.2.0",
+				"map-obj": "1.0.1"
 			}
 		},
 		"decode-uri-component": {
@@ -1814,7 +1814,7 @@
 			"integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
 			"dev": true,
 			"requires": {
-				"core-assert": "^0.2.0"
+				"core-assert": "0.2.1"
 			}
 		},
 		"define-property": {
@@ -1823,8 +1823,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -1833,7 +1833,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1842,7 +1842,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1851,9 +1851,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -1876,13 +1876,13 @@
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"dev": true,
 			"requires": {
-				"globby": "^5.0.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"rimraf": "^2.2.8"
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
 			},
 			"dependencies": {
 				"globby": {
@@ -1891,12 +1891,12 @@
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"arrify": "^1.0.0",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"array-union": "1.0.2",
+						"arrify": "1.0.1",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -1917,7 +1917,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "^2.0.0"
+						"pinkie": "2.0.4"
 					}
 				}
 			}
@@ -1934,7 +1934,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"diff": {
@@ -1949,8 +1949,8 @@
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"path-type": "^3.0.0"
+				"arrify": "1.0.1",
+				"path-type": "3.0.0"
 			},
 			"dependencies": {
 				"path-type": {
@@ -1959,7 +1959,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				}
 			}
@@ -1970,7 +1970,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.2"
 			}
 		},
 		"dot-prop": {
@@ -1979,7 +1979,7 @@
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "1.0.1"
 			}
 		},
 		"duplexer3": {
@@ -1995,7 +1995,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "0.1.1"
 			}
 		},
 		"empower-core": {
@@ -2005,7 +2005,7 @@
 			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
-				"core-js": "^2.0.0"
+				"core-js": "2.5.7"
 			}
 		},
 		"enhance-visitors": {
@@ -2014,7 +2014,7 @@
 			"integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "4.17.10"
 			}
 		},
 		"env-editor": {
@@ -2035,7 +2035,7 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es6-error": {
@@ -2055,44 +2055,44 @@
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
-				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.4",
-				"esquery": "^1.0.0",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
-				"progress": "^2.0.0",
-				"regexpp": "^1.0.1",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.4.1",
+				"concat-stream": "1.6.2",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.7.0",
+				"ignore": "3.3.10",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.12.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"regexpp": "1.1.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.5.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
 				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"globals": {
@@ -2109,8 +2109,8 @@
 			"integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
 			"dev": true,
 			"requires": {
-				"lodash.get": "^4.4.2",
-				"lodash.zip": "^4.2.0"
+				"lodash.get": "4.4.2",
+				"lodash.zip": "4.2.0"
 			}
 		},
 		"eslint-config-prettier": {
@@ -2119,7 +2119,7 @@
 			"integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
 			"dev": true,
 			"requires": {
-				"get-stdin": "^5.0.1"
+				"get-stdin": "5.0.1"
 			},
 			"dependencies": {
 				"get-stdin": {
@@ -2142,11 +2142,11 @@
 			"integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^2.0.0",
-				"chalk": "^2.1.0",
-				"log-symbols": "^2.0.0",
-				"plur": "^2.1.2",
-				"string-width": "^2.0.0"
+				"ansi-escapes": "2.0.0",
+				"chalk": "2.4.1",
+				"log-symbols": "2.2.0",
+				"plur": "2.1.2",
+				"string-width": "2.1.1"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -2163,8 +2163,8 @@
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
-				"resolve": "^1.5.0"
+				"debug": "2.6.9",
+				"resolve": "1.5.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2190,8 +2190,8 @@
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"pkg-dir": "^1.0.0"
+				"debug": "2.6.9",
+				"pkg-dir": "1.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2209,8 +2209,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"ms": {
@@ -2225,7 +2225,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pinkie": {
@@ -2240,7 +2240,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "^2.0.0"
+						"pinkie": "2.0.4"
 					}
 				},
 				"pkg-dir": {
@@ -2249,7 +2249,7 @@
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0"
+						"find-up": "1.1.2"
 					}
 				}
 			}
@@ -2260,14 +2260,14 @@
 			"integrity": "sha512-V0+QZkTYoEXAp8fojaoD85orqNgGfyHWpwQEUqVIRGCRsX9BFnKbG2eX875NgciF3Aouq7smOZcLYqQKgAyH7w==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"deep-strict-equal": "^0.2.0",
-				"enhance-visitors": "^1.0.0",
-				"espree": "^3.1.3",
-				"espurify": "^1.5.0",
-				"import-modules": "^1.1.0",
-				"multimatch": "^2.1.0",
-				"pkg-up": "^2.0.0"
+				"arrify": "1.0.1",
+				"deep-strict-equal": "0.2.0",
+				"enhance-visitors": "1.0.0",
+				"espree": "3.5.4",
+				"espurify": "1.8.0",
+				"import-modules": "1.1.0",
+				"multimatch": "2.1.0",
+				"pkg-up": "2.0.0"
 			}
 		},
 		"eslint-plugin-import": {
@@ -2276,16 +2276,16 @@
 			"integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
 			"dev": true,
 			"requires": {
-				"contains-path": "^0.1.0",
-				"debug": "^2.6.8",
+				"contains-path": "0.1.0",
+				"debug": "2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.1",
-				"eslint-module-utils": "^2.2.0",
-				"has": "^1.0.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.3",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.6.0"
+				"eslint-import-resolver-node": "0.3.2",
+				"eslint-module-utils": "2.2.0",
+				"has": "1.0.3",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"read-pkg-up": "2.0.0",
+				"resolve": "1.8.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -2303,8 +2303,8 @@
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "2.0.2",
+						"isarray": "1.0.0"
 					}
 				},
 				"ms": {
@@ -2319,7 +2319,7 @@
 					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 					"dev": true,
 					"requires": {
-						"path-parse": "^1.0.5"
+						"path-parse": "1.0.5"
 					}
 				}
 			}
@@ -2330,10 +2330,10 @@
 			"integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
 			"dev": true,
 			"requires": {
-				"is-get-set-prop": "^1.0.0",
-				"is-js-type": "^2.0.0",
-				"is-obj-prop": "^1.0.0",
-				"is-proto-prop": "^1.0.0"
+				"is-get-set-prop": "1.0.0",
+				"is-js-type": "2.0.0",
+				"is-obj-prop": "1.0.0",
+				"is-proto-prop": "1.0.1"
 			}
 		},
 		"eslint-plugin-node": {
@@ -2342,10 +2342,10 @@
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
 			"dev": true,
 			"requires": {
-				"ignore": "^3.3.6",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.3.3",
-				"semver": "^5.4.1"
+				"ignore": "3.3.10",
+				"minimatch": "3.0.4",
+				"resolve": "1.5.0",
+				"semver": "5.5.0"
 			}
 		},
 		"eslint-plugin-prettier": {
@@ -2354,8 +2354,8 @@
 			"integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
 			"dev": true,
 			"requires": {
-				"fast-diff": "^1.1.1",
-				"jest-docblock": "^21.0.0"
+				"fast-diff": "1.1.2",
+				"jest-docblock": "21.2.0"
 			}
 		},
 		"eslint-plugin-promise": {
@@ -2370,14 +2370,14 @@
 			"integrity": "sha512-F1JMyd42hx4qGhIaVdOSbDyhcxPgTy4BOzctTCkV+hqebPBUOAQn1f5AhMK2LTyiqCmKiTs8huAErbLBSWKoCQ==",
 			"dev": true,
 			"requires": {
-				"clean-regexp": "^1.0.0",
-				"eslint-ast-utils": "^1.0.0",
-				"import-modules": "^1.1.0",
-				"lodash.camelcase": "^4.1.1",
-				"lodash.kebabcase": "^4.0.1",
-				"lodash.snakecase": "^4.0.1",
-				"lodash.upperfirst": "^4.2.0",
-				"safe-regex": "^1.1.0"
+				"clean-regexp": "1.0.0",
+				"eslint-ast-utils": "1.1.0",
+				"import-modules": "1.1.0",
+				"lodash.camelcase": "4.3.0",
+				"lodash.kebabcase": "4.1.1",
+				"lodash.snakecase": "4.1.1",
+				"lodash.upperfirst": "4.3.1",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"eslint-scope": {
@@ -2386,8 +2386,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -2402,10 +2402,10 @@
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
 			"dev": true,
 			"requires": {
-				"is-url": "^1.2.1",
-				"path-is-absolute": "^1.0.0",
-				"source-map": "^0.5.0",
-				"xtend": "^4.0.0"
+				"is-url": "1.2.4",
+				"path-is-absolute": "1.0.1",
+				"source-map": "0.5.7",
+				"xtend": "4.0.1"
 			}
 		},
 		"espree": {
@@ -2414,8 +2414,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "5.7.1",
+				"acorn-jsx": "3.0.1"
 			}
 		},
 		"esprima": {
@@ -2430,7 +2430,7 @@
 			"integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.0.0"
+				"core-js": "2.5.7"
 			}
 		},
 		"esquery": {
@@ -2439,7 +2439,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -2448,7 +2448,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"estraverse": {
@@ -2469,13 +2469,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"expand-brackets": {
@@ -2484,7 +2484,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"is-posix-bracket": "0.1.1"
 			}
 		},
 		"expand-range": {
@@ -2493,7 +2493,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.4"
 			}
 		},
 		"extend": {
@@ -2508,8 +2508,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -2518,7 +2518,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -2529,9 +2529,9 @@
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.23",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -2540,7 +2540,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -2567,12 +2567,12 @@
 			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
 			"dev": true,
 			"requires": {
-				"@mrmlnc/readdir-enhanced": "^2.2.1",
-				"@nodelib/fs.stat": "^1.0.1",
-				"glob-parent": "^3.1.0",
-				"is-glob": "^4.0.0",
-				"merge2": "^1.2.1",
-				"micromatch": "^3.1.10"
+				"@mrmlnc/readdir-enhanced": "2.2.1",
+				"@nodelib/fs.stat": "1.1.0",
+				"glob-parent": "3.1.0",
+				"is-glob": "4.0.0",
+				"merge2": "1.2.2",
+				"micromatch": "3.1.10"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -2593,16 +2593,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2611,7 +2611,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2631,13 +2631,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2646,7 +2646,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -2655,7 +2655,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -2664,7 +2664,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -2673,7 +2673,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -2684,7 +2684,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -2693,7 +2693,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -2704,9 +2704,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -2723,14 +2723,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2739,7 +2739,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -2748,7 +2748,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2759,10 +2759,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2771,7 +2771,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2782,8 +2782,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -2792,7 +2792,7 @@
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"dev": true,
 							"requires": {
-								"is-extglob": "^2.1.0"
+								"is-extglob": "2.1.1"
 							}
 						}
 					}
@@ -2803,7 +2803,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2812,7 +2812,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2821,9 +2821,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-extglob": {
@@ -2838,7 +2838,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"is-number": {
@@ -2847,7 +2847,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2856,7 +2856,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2879,19 +2879,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"ms": {
@@ -2920,7 +2920,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -2929,8 +2929,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"filename-regex": {
@@ -2945,8 +2945,8 @@
 			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
 			"dev": true,
 			"requires": {
-				"is-object": "~1.0.1",
-				"merge-descriptors": "~1.0.0"
+				"is-object": "1.0.1",
+				"merge-descriptors": "1.0.1"
 			}
 		},
 		"fill-range": {
@@ -2955,11 +2955,11 @@
 			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "3.0.0",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"find-cache-dir": {
@@ -2968,9 +2968,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"commondir": "1.0.1",
+				"make-dir": "1.3.0",
+				"pkg-dir": "2.0.0"
 			}
 		},
 		"find-up": {
@@ -2979,7 +2979,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -2988,10 +2988,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
 			}
 		},
 		"fn-name": {
@@ -3012,7 +3012,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"forever-agent": {
@@ -3027,9 +3027,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
+				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "^2.1.12"
+				"mime-types": "2.1.18"
 			}
 		},
 		"fragment-cache": {
@@ -3038,7 +3038,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"fs.realpath": {
@@ -3054,8 +3054,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3085,8 +3085,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
@@ -3101,7 +3101,7 @@
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3175,7 +3175,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -3192,14 +3192,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -3209,12 +3209,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -3231,7 +3231,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -3241,7 +3241,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -3251,8 +3251,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -3274,7 +3274,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -3290,7 +3290,7 @@
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -3305,8 +3305,8 @@
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -3316,7 +3316,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
@@ -3342,9 +3342,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -3354,16 +3354,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.7",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -3373,8 +3373,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -3391,8 +3391,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -3402,10 +3402,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3427,7 +3427,7 @@
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -3451,8 +3451,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -3476,10 +3476,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -3498,13 +3498,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -3514,7 +3514,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -3564,9 +3564,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -3576,7 +3576,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -3585,7 +3585,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -3602,13 +3602,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -3625,7 +3625,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -3696,7 +3696,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"glob": {
@@ -3705,12 +3705,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -3719,8 +3719,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -3729,7 +3729,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-to-regexp": {
@@ -3744,7 +3744,7 @@
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 			"dev": true,
 			"requires": {
-				"ini": "^1.3.4"
+				"ini": "1.3.5"
 			}
 		},
 		"globals": {
@@ -3759,11 +3759,11 @@
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"dev": true,
 			"requires": {
-				"array-union": "^1.0.1",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-union": "1.0.2",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -3784,7 +3784,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "^2.0.0"
+						"pinkie": "2.0.4"
 					}
 				}
 			}
@@ -3795,17 +3795,17 @@
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
-				"create-error-class": "^3.0.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"is-redirect": "^1.0.0",
-				"is-retry-allowed": "^1.0.0",
-				"is-stream": "^1.0.0",
-				"lowercase-keys": "^1.0.0",
-				"safe-buffer": "^5.0.1",
-				"timed-out": "^4.0.0",
-				"unzip-response": "^2.0.1",
-				"url-parse-lax": "^1.0.0"
+				"create-error-class": "3.0.2",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.1",
+				"safe-buffer": "5.1.2",
+				"timed-out": "4.0.1",
+				"unzip-response": "2.0.1",
+				"url-parse-lax": "1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -3825,8 +3825,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -3835,7 +3835,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -3844,7 +3844,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-color": {
@@ -3865,9 +3865,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -3884,8 +3884,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -3894,7 +3894,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3903,7 +3903,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -3914,7 +3914,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3925,14 +3925,23 @@
 			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
 			"dev": true
 		},
+		"hasha": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+			"integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+			"dev": true,
+			"requires": {
+				"is-stream": "1.1.0"
+			}
+		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -3947,9 +3956,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.2"
 			}
 		},
 		"hullabaloo-config-manager": {
@@ -3958,20 +3967,20 @@
 			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "^4.1.0",
-				"es6-error": "^4.0.2",
-				"graceful-fs": "^4.1.11",
-				"indent-string": "^3.1.0",
-				"json5": "^0.5.1",
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.clonedeepwith": "^4.5.0",
-				"lodash.isequal": "^4.5.0",
-				"lodash.merge": "^4.6.0",
-				"md5-hex": "^2.0.0",
-				"package-hash": "^2.0.0",
-				"pkg-dir": "^2.0.0",
-				"resolve-from": "^3.0.0",
-				"safe-buffer": "^5.0.1"
+				"dot-prop": "4.2.0",
+				"es6-error": "4.1.1",
+				"graceful-fs": "4.1.11",
+				"indent-string": "3.2.0",
+				"json5": "0.5.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.isequal": "4.5.0",
+				"lodash.merge": "4.6.1",
+				"md5-hex": "2.0.0",
+				"package-hash": "2.0.0",
+				"pkg-dir": "2.0.0",
+				"resolve-from": "3.0.0",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"iconv-lite": {
@@ -3980,7 +3989,7 @@
 			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"ignore": {
@@ -4007,8 +4016,8 @@
 			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
 			}
 		},
 		"import-modules": {
@@ -4034,8 +4043,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -4056,20 +4065,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.10",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			}
 		},
 		"invariant": {
@@ -4078,7 +4087,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"irregular-plurals": {
@@ -4093,7 +4102,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-arrayish": {
@@ -4108,7 +4117,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.11.0"
 			}
 		},
 		"is-buffer": {
@@ -4123,7 +4132,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-ci": {
@@ -4132,7 +4141,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "1.1.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -4141,7 +4150,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-descriptor": {
@@ -4150,9 +4159,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4175,7 +4184,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-error": {
@@ -4202,7 +4211,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4223,8 +4232,8 @@
 			"integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
 			"dev": true,
 			"requires": {
-				"get-set-props": "^0.1.0",
-				"lowercase-keys": "^1.0.0"
+				"get-set-props": "0.1.0",
+				"lowercase-keys": "1.0.1"
 			}
 		},
 		"is-glob": {
@@ -4233,7 +4242,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-installed-globally": {
@@ -4242,8 +4251,8 @@
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 			"dev": true,
 			"requires": {
-				"global-dirs": "^0.1.0",
-				"is-path-inside": "^1.0.0"
+				"global-dirs": "0.1.1",
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-js-type": {
@@ -4252,7 +4261,7 @@
 			"integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
 			"dev": true,
 			"requires": {
-				"js-types": "^1.0.0"
+				"js-types": "1.0.0"
 			}
 		},
 		"is-npm": {
@@ -4267,7 +4276,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-obj": {
@@ -4282,8 +4291,8 @@
 			"integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "^1.0.0",
-				"obj-props": "^1.0.0"
+				"lowercase-keys": "1.0.1",
+				"obj-props": "1.1.0"
 			}
 		},
 		"is-object": {
@@ -4298,7 +4307,7 @@
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "^1.1.0"
+				"symbol-observable": "1.2.0"
 			}
 		},
 		"is-odd": {
@@ -4307,7 +4316,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0"
+				"is-number": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -4330,7 +4339,7 @@
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-path-inside": {
@@ -4339,7 +4348,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -4354,7 +4363,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4389,8 +4398,8 @@
 			"integrity": "sha512-dkmgrJB7nfJhH1ySK1/Qn9xLPMv3ZNlPSAPoyUseD6DQzBF6YmbgQnoyy9OM8derNUlDVJlUGdCEhYbcCPfN5A==",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "^1.0.0",
-				"proto-props": "^1.1.0"
+				"lowercase-keys": "1.0.1",
+				"proto-props": "1.1.0"
 			}
 		},
 		"is-redirect": {
@@ -4491,8 +4500,8 @@
 				"@babel/template": "7.0.0-beta.49",
 				"@babel/traverse": "7.0.0-beta.49",
 				"@babel/types": "7.0.0-beta.49",
-				"istanbul-lib-coverage": "^2.0.0",
-				"semver": "^5.5.0"
+				"istanbul-lib-coverage": "2.0.0",
+				"semver": "5.5.0"
 			}
 		},
 		"jest-docblock": {
@@ -4525,8 +4534,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
 			}
 		},
 		"jsbn": {
@@ -4602,7 +4611,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "^1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"last-line-stream": {
@@ -4611,7 +4620,7 @@
 			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
 			"dev": true,
 			"requires": {
-				"through2": "^2.0.0"
+				"through2": "2.0.3"
 			}
 		},
 		"latest-version": {
@@ -4620,7 +4629,7 @@
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 			"dev": true,
 			"requires": {
-				"package-json": "^4.0.0"
+				"package-json": "4.0.1"
 			}
 		},
 		"lcov-parse": {
@@ -4635,8 +4644,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"line-column-path": {
@@ -4651,10 +4660,10 @@
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"strip-bom": "^3.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"strip-bom": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -4671,8 +4680,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -4782,7 +4791,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "2.4.1"
 			}
 		},
 		"lolex": {
@@ -4797,7 +4806,7 @@
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"dev": true,
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"loud-rejection": {
@@ -4806,8 +4815,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"lowercase-keys": {
@@ -4822,8 +4831,8 @@
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"make-dir": {
@@ -4831,7 +4840,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			}
 		},
 		"map-cache": {
@@ -4852,7 +4861,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"matcher": {
@@ -4861,7 +4870,7 @@
 			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.4"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"math-random": {
@@ -4875,7 +4884,7 @@
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
 			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
 			"requires": {
-				"md5-o-matic": "^0.1.1"
+				"md5-o-matic": "0.1.1"
 			}
 		},
 		"md5-o-matic": {
@@ -4889,16 +4898,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -4907,8 +4916,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"load-json-file": {
@@ -4917,11 +4926,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"minimist": {
@@ -4936,7 +4945,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-type": {
@@ -4945,9 +4954,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -4968,7 +4977,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "^2.0.0"
+						"pinkie": "2.0.4"
 					}
 				},
 				"read-pkg": {
@@ -4977,9 +4986,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -4988,8 +4997,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					}
 				},
 				"strip-bom": {
@@ -4998,7 +5007,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -5021,19 +5030,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
 			}
 		},
 		"mime-db": {
@@ -5048,7 +5057,7 @@
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.33.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -5063,7 +5072,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -5078,8 +5087,8 @@
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0"
+				"arrify": "1.0.1",
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"mixin-deep": {
@@ -5088,8 +5097,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5098,7 +5107,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -5130,10 +5139,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
 			}
 		},
 		"mute-stream": {
@@ -5155,18 +5164,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -5201,11 +5210,11 @@
 			"integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"just-extend": "^1.1.27",
-				"lolex": "^2.3.2",
-				"path-to-regexp": "^1.7.0",
-				"text-encoding": "^0.6.4"
+				"@sinonjs/formatio": "2.0.0",
+				"just-extend": "1.1.27",
+				"lolex": "2.7.0",
+				"path-to-regexp": "1.7.0",
+				"text-encoding": "0.6.4"
 			}
 		},
 		"normalize-package-data": {
@@ -5214,10 +5223,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"normalize-path": {
@@ -5226,7 +5235,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"npm-run-path": {
@@ -5235,7 +5244,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"number-is-nan": {
@@ -5250,33 +5259,33 @@
 			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
 			"dev": true,
 			"requires": {
-				"archy": "^1.0.0",
-				"arrify": "^1.0.1",
-				"caching-transform": "^1.0.0",
-				"convert-source-map": "^1.5.1",
-				"debug-log": "^1.0.1",
-				"default-require-extensions": "^1.0.0",
-				"find-cache-dir": "^0.1.1",
-				"find-up": "^2.1.0",
-				"foreground-child": "^1.5.3",
-				"glob": "^7.0.6",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.1.0",
-				"istanbul-lib-instrument": "^2.1.0",
-				"istanbul-lib-report": "^1.1.3",
-				"istanbul-lib-source-maps": "^1.2.5",
-				"istanbul-reports": "^1.4.1",
-				"md5-hex": "^1.2.0",
-				"merge-source-map": "^1.1.0",
-				"micromatch": "^3.1.10",
-				"mkdirp": "^0.5.0",
-				"resolve-from": "^2.0.0",
-				"rimraf": "^2.6.2",
-				"signal-exit": "^3.0.1",
-				"spawn-wrap": "^1.4.2",
-				"test-exclude": "^4.2.0",
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.1",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
+				"glob": "7.1.2",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "2.2.0",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.5",
+				"istanbul-reports": "1.4.1",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.1.0",
+				"micromatch": "3.1.10",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.2",
+				"signal-exit": "3.0.2",
+				"spawn-wrap": "1.4.2",
+				"test-exclude": "4.2.1",
 				"yargs": "11.1.0",
-				"yargs-parser": "^8.0.0"
+				"yargs-parser": "8.1.0"
 			},
 			"dependencies": {
 				"align-text": {
@@ -5285,9 +5294,9 @@
 					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2",
-						"longest": "^1.0.1",
-						"repeat-string": "^1.5.2"
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
 					}
 				},
 				"amdefine": {
@@ -5308,7 +5317,7 @@
 					"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "^1.0.0"
+						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
@@ -5377,13 +5386,13 @@
 					"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
 					"dev": true,
 					"requires": {
-						"cache-base": "^1.0.1",
-						"class-utils": "^0.3.5",
-						"component-emitter": "^1.2.1",
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.1",
-						"mixin-deep": "^1.2.0",
-						"pascalcase": "^0.1.1"
+						"cache-base": "1.0.1",
+						"class-utils": "0.3.6",
+						"component-emitter": "1.2.1",
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"mixin-deep": "1.3.1",
+						"pascalcase": "0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -5392,7 +5401,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -5401,7 +5410,7 @@
 							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -5410,7 +5419,7 @@
 							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -5419,9 +5428,9 @@
 							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"kind-of": {
@@ -5438,7 +5447,7 @@
 					"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 					"dev": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -5448,16 +5457,16 @@
 					"integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -5466,7 +5475,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5483,15 +5492,15 @@
 					"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
 					"dev": true,
 					"requires": {
-						"collection-visit": "^1.0.0",
-						"component-emitter": "^1.2.1",
-						"get-value": "^2.0.6",
-						"has-value": "^1.0.0",
-						"isobject": "^3.0.1",
-						"set-value": "^2.0.0",
-						"to-object-path": "^0.3.0",
-						"union-value": "^1.0.0",
-						"unset-value": "^1.0.0"
+						"collection-visit": "1.0.0",
+						"component-emitter": "1.2.1",
+						"get-value": "2.0.6",
+						"has-value": "1.0.0",
+						"isobject": "3.0.1",
+						"set-value": "2.0.0",
+						"to-object-path": "0.3.0",
+						"union-value": "1.0.0",
+						"unset-value": "1.0.0"
 					}
 				},
 				"caching-transform": {
@@ -5500,9 +5509,9 @@
 					"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
 					"dev": true,
 					"requires": {
-						"md5-hex": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"write-file-atomic": "^1.1.4"
+						"md5-hex": "1.3.0",
+						"mkdirp": "0.5.1",
+						"write-file-atomic": "1.3.4"
 					}
 				},
 				"camelcase": {
@@ -5519,8 +5528,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "^0.1.3",
-						"lazy-cache": "^1.0.3"
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
 					}
 				},
 				"class-utils": {
@@ -5529,10 +5538,10 @@
 					"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
 					"dev": true,
 					"requires": {
-						"arr-union": "^3.1.0",
-						"define-property": "^0.2.5",
-						"isobject": "^3.0.0",
-						"static-extend": "^0.1.1"
+						"arr-union": "3.1.0",
+						"define-property": "0.2.5",
+						"isobject": "3.0.1",
+						"static-extend": "0.1.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -5541,7 +5550,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						}
 					}
@@ -5553,8 +5562,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
@@ -5579,8 +5588,8 @@
 					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 					"dev": true,
 					"requires": {
-						"map-visit": "^1.0.0",
-						"object-visit": "^1.0.0"
+						"map-visit": "1.0.0",
+						"object-visit": "1.0.1"
 					}
 				},
 				"commondir": {
@@ -5619,8 +5628,8 @@
 					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.3",
+						"which": "1.3.1"
 					}
 				},
 				"debug": {
@@ -5656,7 +5665,7 @@
 					"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 					"dev": true,
 					"requires": {
-						"strip-bom": "^2.0.0"
+						"strip-bom": "2.0.0"
 					}
 				},
 				"define-property": {
@@ -5665,8 +5674,8 @@
 					"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.2",
-						"isobject": "^3.0.1"
+						"is-descriptor": "1.0.2",
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"is-accessor-descriptor": {
@@ -5675,7 +5684,7 @@
 							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -5684,7 +5693,7 @@
 							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -5693,9 +5702,9 @@
 							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"kind-of": {
@@ -5712,7 +5721,7 @@
 					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 					"dev": true,
 					"requires": {
-						"is-arrayish": "^0.2.1"
+						"is-arrayish": "0.2.1"
 					}
 				},
 				"execa": {
@@ -5721,13 +5730,13 @@
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
@@ -5736,9 +5745,9 @@
 							"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 							"dev": true,
 							"requires": {
-								"lru-cache": "^4.0.1",
-								"shebang-command": "^1.2.0",
-								"which": "^1.2.9"
+								"lru-cache": "4.1.3",
+								"shebang-command": "1.2.0",
+								"which": "1.3.1"
 							}
 						}
 					}
@@ -5749,13 +5758,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -5773,7 +5782,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -5782,7 +5791,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5793,8 +5802,8 @@
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"dev": true,
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -5803,7 +5812,7 @@
 							"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
 							"dev": true,
 							"requires": {
-								"is-plain-object": "^2.0.4"
+								"is-plain-object": "2.0.4"
 							}
 						}
 					}
@@ -5814,14 +5823,14 @@
 					"integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -5830,7 +5839,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -5839,7 +5848,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -5848,7 +5857,7 @@
 							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -5857,7 +5866,7 @@
 							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -5866,9 +5875,9 @@
 							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"kind-of": {
@@ -5885,10 +5894,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -5897,7 +5906,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5908,9 +5917,9 @@
 					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
 					"dev": true,
 					"requires": {
-						"commondir": "^1.0.1",
-						"mkdirp": "^0.5.1",
-						"pkg-dir": "^1.0.0"
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
 					}
 				},
 				"find-up": {
@@ -5919,7 +5928,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
@@ -5934,8 +5943,8 @@
 					"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^4",
-						"signal-exit": "^3.0.0"
+						"cross-spawn": "4.0.2",
+						"signal-exit": "3.0.2"
 					}
 				},
 				"fragment-cache": {
@@ -5944,7 +5953,7 @@
 					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 					"dev": true,
 					"requires": {
-						"map-cache": "^0.2.2"
+						"map-cache": "0.2.2"
 					}
 				},
 				"fs.realpath": {
@@ -5977,12 +5986,12 @@
 					"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"graceful-fs": {
@@ -5997,10 +6006,10 @@
 					"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 					"dev": true,
 					"requires": {
-						"async": "^1.4.0",
-						"optimist": "^0.6.1",
-						"source-map": "^0.4.4",
-						"uglify-js": "^2.6"
+						"async": "1.5.2",
+						"optimist": "0.6.1",
+						"source-map": "0.4.4",
+						"uglify-js": "2.8.29"
 					},
 					"dependencies": {
 						"source-map": {
@@ -6009,7 +6018,7 @@
 							"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 							"dev": true,
 							"requires": {
-								"amdefine": ">=0.0.4"
+								"amdefine": "1.0.1"
 							}
 						}
 					}
@@ -6020,9 +6029,9 @@
 					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.6",
-						"has-values": "^1.0.0",
-						"isobject": "^3.0.0"
+						"get-value": "2.0.6",
+						"has-values": "1.0.0",
+						"isobject": "3.0.1"
 					}
 				},
 				"has-values": {
@@ -6031,8 +6040,8 @@
 					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"kind-of": "^4.0.0"
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6041,7 +6050,7 @@
 							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -6064,8 +6073,8 @@
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -6086,7 +6095,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-arrayish": {
@@ -6107,7 +6116,7 @@
 					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 					"dev": true,
 					"requires": {
-						"builtin-modules": "^1.0.0"
+						"builtin-modules": "1.1.1"
 					}
 				},
 				"is-data-descriptor": {
@@ -6116,7 +6125,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-descriptor": {
@@ -6125,9 +6134,9 @@
 					"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6156,7 +6165,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-odd": {
@@ -6165,7 +6174,7 @@
 					"integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
 					"dev": true,
 					"requires": {
-						"is-number": "^4.0.0"
+						"is-number": "4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -6182,7 +6191,7 @@
 					"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
 					"dev": true,
 					"requires": {
-						"isobject": "^3.0.1"
+						"isobject": "3.0.1"
 					}
 				},
 				"is-stream": {
@@ -6233,7 +6242,7 @@
 					"integrity": "sha1-hTjZcDcss3FtU+VVI91UtVeo2Js=",
 					"dev": true,
 					"requires": {
-						"append-transform": "^0.4.0"
+						"append-transform": "0.4.0"
 					}
 				},
 				"istanbul-lib-report": {
@@ -6242,10 +6251,10 @@
 					"integrity": "sha1-LfEhiMD6d5kMDSF20tC6M5QYglk=",
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "^1.1.2",
-						"mkdirp": "^0.5.1",
-						"path-parse": "^1.0.5",
-						"supports-color": "^3.1.2"
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
 					},
 					"dependencies": {
 						"has-flag": {
@@ -6260,7 +6269,7 @@
 							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 							"dev": true,
 							"requires": {
-								"has-flag": "^1.0.0"
+								"has-flag": "1.0.0"
 							}
 						}
 					}
@@ -6271,11 +6280,11 @@
 					"integrity": "sha1-/+a+Tnq4bTYD5CkNVJkLFFBvybE=",
 					"dev": true,
 					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
 					}
 				},
 				"istanbul-reports": {
@@ -6284,7 +6293,7 @@
 					"integrity": "sha1-Ty6OkoqnoF0dpsQn1AmLJlXsczQ=",
 					"dev": true,
 					"requires": {
-						"handlebars": "^4.0.3"
+						"handlebars": "4.0.11"
 					}
 				},
 				"kind-of": {
@@ -6293,7 +6302,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"lazy-cache": {
@@ -6309,7 +6318,7 @@
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
-						"invert-kv": "^1.0.0"
+						"invert-kv": "1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -6318,11 +6327,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"locate-path": {
@@ -6331,8 +6340,8 @@
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
 					},
 					"dependencies": {
 						"path-exists": {
@@ -6355,8 +6364,8 @@
 					"integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
 					"dev": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
 					}
 				},
 				"map-cache": {
@@ -6371,7 +6380,7 @@
 					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 					"dev": true,
 					"requires": {
-						"object-visit": "^1.0.0"
+						"object-visit": "1.0.1"
 					}
 				},
 				"md5-hex": {
@@ -6380,7 +6389,7 @@
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "^0.1.1"
+						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
@@ -6395,7 +6404,7 @@
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
+						"mimic-fn": "1.2.0"
 					}
 				},
 				"merge-source-map": {
@@ -6404,7 +6413,7 @@
 					"integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
 					"dev": true,
 					"requires": {
-						"source-map": "^0.6.1"
+						"source-map": "0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
@@ -6421,19 +6430,19 @@
 					"integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6456,7 +6465,7 @@
 					"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -6471,8 +6480,8 @@
 					"integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
 					"dev": true,
 					"requires": {
-						"for-in": "^1.0.2",
-						"is-extendable": "^1.0.1"
+						"for-in": "1.0.2",
+						"is-extendable": "1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -6481,7 +6490,7 @@
 							"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
 							"dev": true,
 							"requires": {
-								"is-plain-object": "^2.0.4"
+								"is-plain-object": "2.0.4"
 							}
 						}
 					}
@@ -6507,18 +6516,18 @@
 					"integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"fragment-cache": "^0.2.1",
-						"is-odd": "^2.0.0",
-						"is-windows": "^1.0.2",
-						"kind-of": "^6.0.2",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"fragment-cache": "0.2.1",
+						"is-odd": "2.0.0",
+						"is-windows": "1.0.2",
+						"kind-of": "6.0.2",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6535,10 +6544,10 @@
 					"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"is-builtin-module": "^1.0.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
+						"hosted-git-info": "2.6.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3"
 					}
 				},
 				"npm-run-path": {
@@ -6547,7 +6556,7 @@
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
-						"path-key": "^2.0.0"
+						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
@@ -6568,9 +6577,9 @@
 					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 					"dev": true,
 					"requires": {
-						"copy-descriptor": "^0.1.0",
-						"define-property": "^0.2.5",
-						"kind-of": "^3.0.3"
+						"copy-descriptor": "0.1.1",
+						"define-property": "0.2.5",
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -6579,7 +6588,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						}
 					}
@@ -6590,7 +6599,7 @@
 					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 					"dev": true,
 					"requires": {
-						"isobject": "^3.0.0"
+						"isobject": "3.0.1"
 					}
 				},
 				"object.pick": {
@@ -6599,7 +6608,7 @@
 					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 					"dev": true,
 					"requires": {
-						"isobject": "^3.0.1"
+						"isobject": "3.0.1"
 					}
 				},
 				"once": {
@@ -6608,7 +6617,7 @@
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"optimist": {
@@ -6617,8 +6626,8 @@
 					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 					"dev": true,
 					"requires": {
-						"minimist": "~0.0.1",
-						"wordwrap": "~0.0.2"
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
 					}
 				},
 				"os-homedir": {
@@ -6633,9 +6642,9 @@
 					"integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
 					}
 				},
 				"p-finally": {
@@ -6650,7 +6659,7 @@
 					"integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
 					"dev": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "1.0.0"
 					}
 				},
 				"p-locate": {
@@ -6659,7 +6668,7 @@
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "1.2.0"
 					}
 				},
 				"p-try": {
@@ -6674,7 +6683,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "1.3.1"
 					}
 				},
 				"pascalcase": {
@@ -6689,7 +6698,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
@@ -6716,9 +6725,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -6739,7 +6748,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "^2.0.0"
+						"pinkie": "2.0.4"
 					}
 				},
 				"pkg-dir": {
@@ -6748,7 +6757,7 @@
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0"
+						"find-up": "1.1.2"
 					},
 					"dependencies": {
 						"find-up": {
@@ -6757,8 +6766,8 @@
 							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 							"dev": true,
 							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
 							}
 						}
 					}
@@ -6781,9 +6790,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -6792,8 +6801,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -6802,8 +6811,8 @@
 							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 							"dev": true,
 							"requires": {
-								"path-exists": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
 							}
 						}
 					}
@@ -6814,8 +6823,8 @@
 					"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^3.0.2",
-						"safe-regex": "^1.1.0"
+						"extend-shallow": "3.0.2",
+						"safe-regex": "1.1.0"
 					}
 				},
 				"repeat-element": {
@@ -6867,7 +6876,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "^0.1.1"
+						"align-text": "0.1.4"
 					}
 				},
 				"rimraf": {
@@ -6876,7 +6885,7 @@
 					"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-regex": {
@@ -6885,7 +6894,7 @@
 					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 					"dev": true,
 					"requires": {
-						"ret": "~0.1.10"
+						"ret": "0.1.15"
 					}
 				},
 				"semver": {
@@ -6906,10 +6915,10 @@
 					"integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.3",
-						"split-string": "^3.0.1"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"split-string": "3.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -6918,7 +6927,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -6929,7 +6938,7 @@
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
-						"shebang-regex": "^1.0.0"
+						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
@@ -6956,14 +6965,14 @@
 					"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
 					"dev": true,
 					"requires": {
-						"base": "^0.11.1",
-						"debug": "^2.2.0",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"map-cache": "^0.2.2",
-						"source-map": "^0.5.6",
-						"source-map-resolve": "^0.5.0",
-						"use": "^3.1.0"
+						"base": "0.11.2",
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"map-cache": "0.2.2",
+						"source-map": "0.5.7",
+						"source-map-resolve": "0.5.2",
+						"use": "3.1.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -6981,7 +6990,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -6990,7 +6999,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7001,9 +7010,9 @@
 					"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
 					"dev": true,
 					"requires": {
-						"define-property": "^1.0.0",
-						"isobject": "^3.0.0",
-						"snapdragon-util": "^3.0.1"
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"snapdragon-util": "3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -7012,7 +7021,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -7021,7 +7030,7 @@
 							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -7030,7 +7039,7 @@
 							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^6.0.0"
+								"kind-of": "6.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -7039,9 +7048,9 @@
 							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^1.0.0",
-								"is-data-descriptor": "^1.0.0",
-								"kind-of": "^6.0.2"
+								"is-accessor-descriptor": "1.0.0",
+								"is-data-descriptor": "1.0.0",
+								"kind-of": "6.0.2"
 							}
 						},
 						"kind-of": {
@@ -7058,7 +7067,7 @@
 					"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.2.0"
+						"kind-of": "3.2.2"
 					}
 				},
 				"source-map": {
@@ -7073,11 +7082,11 @@
 					"integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
 					"dev": true,
 					"requires": {
-						"atob": "^2.1.1",
-						"decode-uri-component": "^0.2.0",
-						"resolve-url": "^0.2.1",
-						"source-map-url": "^0.4.0",
-						"urix": "^0.1.0"
+						"atob": "2.1.1",
+						"decode-uri-component": "0.2.0",
+						"resolve-url": "0.2.1",
+						"source-map-url": "0.4.0",
+						"urix": "0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -7092,12 +7101,12 @@
 					"integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
 					"dev": true,
 					"requires": {
-						"foreground-child": "^1.5.6",
-						"mkdirp": "^0.5.0",
-						"os-homedir": "^1.0.1",
-						"rimraf": "^2.6.2",
-						"signal-exit": "^3.0.2",
-						"which": "^1.3.0"
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.2",
+						"signal-exit": "3.0.2",
+						"which": "1.3.1"
 					}
 				},
 				"spdx-correct": {
@@ -7106,8 +7115,8 @@
 					"integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -7122,8 +7131,8 @@
 					"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -7138,7 +7147,7 @@
 					"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^3.0.0"
+						"extend-shallow": "3.0.2"
 					}
 				},
 				"static-extend": {
@@ -7147,8 +7156,8 @@
 					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 					"dev": true,
 					"requires": {
-						"define-property": "^0.2.5",
-						"object-copy": "^0.1.0"
+						"define-property": "0.2.5",
+						"object-copy": "0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -7157,7 +7166,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						}
 					}
@@ -7168,8 +7177,8 @@
 					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -7178,7 +7187,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -7187,7 +7196,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
@@ -7202,11 +7211,11 @@
 					"integrity": "sha1-36Ii8DSAvKaSB8pyizfXS0X3JPo=",
 					"dev": true,
 					"requires": {
-						"arrify": "^1.0.1",
-						"micromatch": "^3.1.8",
-						"object-assign": "^4.1.0",
-						"read-pkg-up": "^1.0.1",
-						"require-main-filename": "^1.0.1"
+						"arrify": "1.0.1",
+						"micromatch": "3.1.10",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
 					}
 				},
 				"to-object-path": {
@@ -7215,7 +7224,7 @@
 					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"to-regex": {
@@ -7224,10 +7233,10 @@
 					"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
 					"dev": true,
 					"requires": {
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"regex-not": "^1.0.2",
-						"safe-regex": "^1.1.0"
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"regex-not": "1.0.2",
+						"safe-regex": "1.1.0"
 					}
 				},
 				"to-regex-range": {
@@ -7236,8 +7245,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				},
 				"uglify-js": {
@@ -7247,9 +7256,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
@@ -7259,9 +7268,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "^1.0.2",
-								"cliui": "^2.1.0",
-								"decamelize": "^1.0.0",
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -7280,10 +7289,10 @@
 					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 					"dev": true,
 					"requires": {
-						"arr-union": "^3.1.0",
-						"get-value": "^2.0.6",
-						"is-extendable": "^0.1.1",
-						"set-value": "^0.4.3"
+						"arr-union": "3.1.0",
+						"get-value": "2.0.6",
+						"is-extendable": "0.1.1",
+						"set-value": "0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7292,7 +7301,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"set-value": {
@@ -7301,10 +7310,10 @@
 							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 							"dev": true,
 							"requires": {
-								"extend-shallow": "^2.0.1",
-								"is-extendable": "^0.1.1",
-								"is-plain-object": "^2.0.1",
-								"to-object-path": "^0.3.0"
+								"extend-shallow": "2.0.1",
+								"is-extendable": "0.1.1",
+								"is-plain-object": "2.0.4",
+								"to-object-path": "0.3.0"
 							}
 						}
 					}
@@ -7315,8 +7324,8 @@
 					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 					"dev": true,
 					"requires": {
-						"has-value": "^0.3.1",
-						"isobject": "^3.0.0"
+						"has-value": "0.3.1",
+						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"has-value": {
@@ -7325,9 +7334,9 @@
 							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 							"dev": true,
 							"requires": {
-								"get-value": "^2.0.3",
-								"has-values": "^0.1.4",
-								"isobject": "^2.0.0"
+								"get-value": "2.0.6",
+								"has-values": "0.1.4",
+								"isobject": "2.1.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -7361,7 +7370,7 @@
 					"integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.2"
+						"kind-of": "6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -7378,8 +7387,8 @@
 					"integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
 					"dev": true,
 					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
 					}
 				},
 				"which": {
@@ -7388,7 +7397,7 @@
 					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
 					"dev": true,
 					"requires": {
-						"isexe": "^2.0.0"
+						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
@@ -7416,8 +7425,8 @@
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -7432,7 +7441,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "^1.0.0"
+								"number-is-nan": "1.0.1"
 							}
 						},
 						"string-width": {
@@ -7441,9 +7450,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						},
 						"strip-ansi": {
@@ -7452,7 +7461,7 @@
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^2.0.0"
+								"ansi-regex": "2.1.1"
 							}
 						}
 					}
@@ -7469,9 +7478,9 @@
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"slide": "^1.1.5"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
 					}
 				},
 				"y18n": {
@@ -7492,18 +7501,18 @@
 					"integrity": "sha1-kLhpk07W6HERXqL/WLA/RyTtLXc=",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -7518,9 +7527,9 @@
 							"integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
 							"dev": true,
 							"requires": {
-								"string-width": "^2.1.1",
-								"strip-ansi": "^4.0.0",
-								"wrap-ansi": "^2.0.0"
+								"string-width": "2.1.1",
+								"strip-ansi": "4.0.0",
+								"wrap-ansi": "2.1.0"
 							}
 						},
 						"yargs-parser": {
@@ -7529,7 +7538,7 @@
 							"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 							"dev": true,
 							"requires": {
-								"camelcase": "^4.1.0"
+								"camelcase": "4.1.0"
 							}
 						}
 					}
@@ -7540,7 +7549,7 @@
 					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -7577,9 +7586,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7588,7 +7597,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -7599,7 +7608,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -7616,8 +7625,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -7626,7 +7635,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -7643,8 +7652,8 @@
 			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
 			"dev": true,
 			"requires": {
-				"is-observable": "^0.2.0",
-				"symbol-observable": "^1.0.4"
+				"is-observable": "0.2.0",
+				"symbol-observable": "1.2.0"
 			},
 			"dependencies": {
 				"is-observable": {
@@ -7653,7 +7662,7 @@
 					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 					"dev": true,
 					"requires": {
-						"symbol-observable": "^0.2.2"
+						"symbol-observable": "0.2.4"
 					},
 					"dependencies": {
 						"symbol-observable": {
@@ -7672,7 +7681,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -7681,7 +7690,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"open-editor": {
@@ -7690,9 +7699,9 @@
 			"integrity": "sha1-dcoj8LdNSz9V7guKTg9cIyXrd18=",
 			"dev": true,
 			"requires": {
-				"env-editor": "^0.3.1",
-				"line-column-path": "^1.0.0",
-				"opn": "^5.0.0"
+				"env-editor": "0.3.1",
+				"line-column-path": "1.0.0",
+				"opn": "5.3.0"
 			}
 		},
 		"opn": {
@@ -7701,7 +7710,7 @@
 			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
 			"dev": true,
 			"requires": {
-				"is-wsl": "^1.1.0"
+				"is-wsl": "1.1.0"
 			}
 		},
 		"option-chain": {
@@ -7716,12 +7725,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			}
 		},
 		"os-homedir": {
@@ -7748,7 +7757,7 @@
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -7757,7 +7766,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.3.0"
 			}
 		},
 		"p-try": {
@@ -7771,10 +7780,10 @@
 			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
 			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"lodash.flattendeep": "^4.4.0",
-				"md5-hex": "^2.0.0",
-				"release-zalgo": "^1.0.0"
+				"graceful-fs": "4.1.11",
+				"lodash.flattendeep": "4.4.0",
+				"md5-hex": "2.0.0",
+				"release-zalgo": "1.0.0"
 			}
 		},
 		"package-json": {
@@ -7783,10 +7792,10 @@
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"dev": true,
 			"requires": {
-				"got": "^6.7.1",
-				"registry-auth-token": "^3.0.1",
-				"registry-url": "^3.0.3",
-				"semver": "^5.1.0"
+				"got": "6.7.1",
+				"registry-auth-token": "3.3.2",
+				"registry-url": "3.1.0",
+				"semver": "5.5.0"
 			}
 		},
 		"parse-glob": {
@@ -7795,10 +7804,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -7807,7 +7816,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.2"
 			}
 		},
 		"parse-ms": {
@@ -7881,7 +7890,7 @@
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "2.3.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -7915,7 +7924,7 @@
 			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^1.0.0"
+				"pinkie": "1.0.0"
 			}
 		},
 		"pkg-conf": {
@@ -7924,8 +7933,8 @@
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
-				"load-json-file": "^4.0.0"
+				"find-up": "2.1.0",
+				"load-json-file": "4.0.0"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -7934,10 +7943,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"parse-json": {
@@ -7946,8 +7955,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2"
 					}
 				}
 			}
@@ -7958,7 +7967,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"pkg-up": {
@@ -7967,7 +7976,7 @@
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"plur": {
@@ -7976,7 +7985,7 @@
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "^1.0.0"
+				"irregular-plurals": "1.4.0"
 			}
 		},
 		"pluralize": {
@@ -8021,7 +8030,7 @@
 			"integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
 			"dev": true,
 			"requires": {
-				"parse-ms": "^1.0.0"
+				"parse-ms": "1.0.1"
 			},
 			"dependencies": {
 				"parse-ms": {
@@ -8062,9 +8071,9 @@
 			"integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
 			"dev": true,
 			"requires": {
-				"fill-keys": "^1.0.2",
-				"module-not-found-error": "^1.0.0",
-				"resolve": "~1.5.0"
+				"fill-keys": "1.0.2",
+				"module-not-found-error": "1.0.1",
+				"resolve": "1.5.0"
 			}
 		},
 		"pseudomap": {
@@ -8097,9 +8106,9 @@
 			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
+				"is-number": "4.0.0",
+				"kind-of": "6.0.2",
+				"math-random": "1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -8122,10 +8131,10 @@
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
 			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
+				"deep-extend": "0.6.0",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -8142,9 +8151,9 @@
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"load-json-file": "2.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "2.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -8153,8 +8162,8 @@
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"find-up": "2.1.0",
+				"read-pkg": "2.0.0"
 			}
 		},
 		"readable-stream": {
@@ -8163,13 +8172,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -8178,10 +8187,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.6",
+				"set-immediate-shim": "1.0.1"
 			}
 		},
 		"redent": {
@@ -8190,8 +8199,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
 			},
 			"dependencies": {
 				"indent-string": {
@@ -8200,7 +8209,7 @@
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"dev": true,
 					"requires": {
-						"repeating": "^2.0.0"
+						"repeating": "2.0.1"
 					}
 				}
 			}
@@ -8223,7 +8232,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -8232,8 +8241,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexpp": {
@@ -8248,9 +8257,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.4.0",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"registry-auth-token": {
@@ -8259,8 +8268,8 @@
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"dev": true,
 			"requires": {
-				"rc": "^1.1.6",
-				"safe-buffer": "^5.0.1"
+				"rc": "1.2.8",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"registry-url": {
@@ -8269,7 +8278,7 @@
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"dev": true,
 			"requires": {
-				"rc": "^1.0.1"
+				"rc": "1.2.8"
 			}
 		},
 		"regjsgen": {
@@ -8284,7 +8293,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			}
 		},
 		"release-zalgo": {
@@ -8292,7 +8301,7 @@
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
 			"requires": {
-				"es6-error": "^4.0.1"
+				"es6-error": "4.1.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -8319,7 +8328,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"request": {
@@ -8328,26 +8337,26 @@
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.7.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
 			}
 		},
 		"require-precompiled": {
@@ -8362,8 +8371,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -8380,7 +8389,7 @@
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -8389,7 +8398,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -8410,8 +8419,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -8426,7 +8435,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"run-async": {
@@ -8435,7 +8444,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -8450,7 +8459,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"safe-buffer": {
@@ -8465,7 +8474,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -8492,7 +8501,7 @@
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 			"dev": true,
 			"requires": {
-				"semver": "^5.0.3"
+				"semver": "5.5.0"
 			}
 		},
 		"serialize-error": {
@@ -8513,10 +8522,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -8525,7 +8534,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -8536,7 +8545,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -8556,13 +8565,13 @@
 			"integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"diff": "^3.5.0",
-				"lodash.get": "^4.4.2",
-				"lolex": "^2.4.2",
-				"nise": "^1.3.3",
-				"supports-color": "^5.4.0",
-				"type-detect": "^4.0.8"
+				"@sinonjs/formatio": "2.0.0",
+				"diff": "3.5.0",
+				"lodash.get": "4.4.2",
+				"lolex": "2.7.0",
+				"nise": "1.4.2",
+				"supports-color": "5.4.0",
+				"type-detect": "4.0.8"
 			}
 		},
 		"slash": {
@@ -8577,7 +8586,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0"
+				"is-fullwidth-code-point": "2.0.0"
 			}
 		},
 		"slide": {
@@ -8592,14 +8601,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -8617,7 +8626,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -8626,7 +8635,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"ms": {
@@ -8643,9 +8652,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8654,7 +8663,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -8663,7 +8672,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -8672,7 +8681,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -8681,9 +8690,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -8706,7 +8715,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			}
 		},
 		"sort-keys": {
@@ -8715,7 +8724,7 @@
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "^1.0.0"
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"source-map": {
@@ -8730,11 +8739,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.1",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -8743,8 +8752,8 @@
 			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"buffer-from": "1.1.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -8767,8 +8776,8 @@
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -8783,8 +8792,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -8799,7 +8808,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -8814,15 +8823,15 @@
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"stack-utils": {
@@ -8837,8 +8846,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8847,7 +8856,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -8858,8 +8867,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			}
 		},
 		"string_decoder": {
@@ -8868,7 +8877,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"strip-ansi": {
@@ -8877,7 +8886,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0"
+				"ansi-regex": "3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8900,7 +8909,7 @@
 			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "^0.2.1"
+				"is-utf8": "0.2.1"
 			}
 		},
 		"strip-eof": {
@@ -8915,7 +8924,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "^4.0.1"
+				"get-stdin": "4.0.1"
 			}
 		},
 		"strip-json-comments": {
@@ -8930,11 +8939,11 @@
 			"integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"indent-string": "^3.2.0",
-				"js-yaml": "^3.10.0",
-				"serialize-error": "^2.1.0",
-				"strip-ansi": "^4.0.0"
+				"arrify": "1.0.1",
+				"indent-string": "3.2.0",
+				"js-yaml": "3.12.0",
+				"serialize-error": "2.1.0",
+				"strip-ansi": "4.0.0"
 			}
 		},
 		"supports-color": {
@@ -8943,7 +8952,7 @@
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "3.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -8966,12 +8975,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-keywords": "^2.1.0",
-				"chalk": "^2.1.0",
-				"lodash": "^4.17.4",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.4.1",
+				"lodash": "4.17.10",
 				"slice-ansi": "1.0.0",
-				"string-width": "^2.1.1"
+				"string-width": "2.1.1"
 			}
 		},
 		"term-size": {
@@ -8980,7 +8989,7 @@
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0"
+				"execa": "0.7.0"
 			}
 		},
 		"text-encoding": {
@@ -9013,8 +9022,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.1.5",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.6",
+				"xtend": "4.0.1"
 			}
 		},
 		"time-zone": {
@@ -9035,7 +9044,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"to-fast-properties": {
@@ -9050,7 +9059,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"to-regex": {
@@ -9059,10 +9068,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -9071,8 +9080,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -9081,7 +9090,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				}
 			}
@@ -9092,7 +9101,7 @@
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.4.1"
+				"punycode": "1.4.1"
 			}
 		},
 		"trim-newlines": {
@@ -9119,7 +9128,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -9135,7 +9144,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"type-detect": {
@@ -9162,10 +9171,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -9174,7 +9183,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -9183,10 +9192,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -9197,7 +9206,7 @@
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 			"dev": true,
 			"requires": {
-				"crypto-random-string": "^1.0.0"
+				"crypto-random-string": "1.0.0"
 			}
 		},
 		"unique-temp-dir": {
@@ -9206,8 +9215,8 @@
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1",
-				"os-tmpdir": "^1.0.1",
+				"mkdirp": "0.5.1",
+				"os-tmpdir": "1.0.2",
 				"uid2": "0.0.3"
 			}
 		},
@@ -9217,8 +9226,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -9227,9 +9236,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -9269,16 +9278,16 @@
 			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 			"dev": true,
 			"requires": {
-				"boxen": "^1.2.1",
-				"chalk": "^2.0.1",
-				"configstore": "^3.0.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^1.0.10",
-				"is-installed-globally": "^0.1.0",
-				"is-npm": "^1.0.0",
-				"latest-version": "^3.0.0",
-				"semver-diff": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
+				"boxen": "1.3.0",
+				"chalk": "2.4.1",
+				"configstore": "3.1.2",
+				"import-lazy": "2.1.0",
+				"is-ci": "1.1.0",
+				"is-installed-globally": "0.1.0",
+				"is-npm": "1.0.0",
+				"latest-version": "3.1.0",
+				"semver-diff": "2.1.0",
+				"xdg-basedir": "3.0.0"
 			}
 		},
 		"urix": {
@@ -9293,7 +9302,7 @@
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "^1.0.1"
+				"prepend-http": "1.0.4"
 			}
 		},
 		"use": {
@@ -9302,7 +9311,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.2"
+				"kind-of": "6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -9331,8 +9340,8 @@
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"verror": {
@@ -9341,9 +9350,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"well-known-symbols": {
@@ -9358,7 +9367,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"widest-line": {
@@ -9367,7 +9376,7 @@
 			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1"
+				"string-width": "2.1.1"
 			}
 		},
 		"wordwrap": {
@@ -9388,7 +9397,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -9396,9 +9405,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"write-json-file": {
@@ -9407,12 +9416,12 @@
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 			"dev": true,
 			"requires": {
-				"detect-indent": "^5.0.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^1.0.0",
-				"pify": "^3.0.0",
-				"sort-keys": "^2.0.0",
-				"write-file-atomic": "^2.0.0"
+				"detect-indent": "5.0.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.3.0",
+				"pify": "3.0.0",
+				"sort-keys": "2.0.0",
+				"write-file-atomic": "2.3.0"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -9429,8 +9438,8 @@
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
 			"dev": true,
 			"requires": {
-				"sort-keys": "^2.0.0",
-				"write-json-file": "^2.2.0"
+				"sort-keys": "2.0.0",
+				"write-json-file": "2.3.0"
 			}
 		},
 		"xdg-basedir": {
@@ -9445,36 +9454,36 @@
 			"integrity": "sha512-pQp9cMptNOm3Ru8Ks4M1lQmTidYmn0kPrlkJNM3mCDMMhpQgiBzEWtekeQP/qH+rmnV7aZZv2ttaK30TjTtpEQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"debug": "^3.1.0",
-				"eslint": "^4.19.1",
-				"eslint-config-prettier": "^2.9.0",
-				"eslint-config-xo": "^0.22.0",
-				"eslint-formatter-pretty": "^1.3.0",
-				"eslint-plugin-ava": "^4.5.0",
-				"eslint-plugin-import": "^2.11.0",
-				"eslint-plugin-no-use-extend-native": "^0.3.12",
-				"eslint-plugin-node": "^6.0.0",
-				"eslint-plugin-prettier": "^2.6.0",
-				"eslint-plugin-promise": "^3.7.0",
-				"eslint-plugin-unicorn": "^4.0.3",
-				"get-stdin": "^6.0.0",
-				"globby": "^8.0.0",
-				"has-flag": "^3.0.0",
-				"lodash.isequal": "^4.5.0",
-				"lodash.mergewith": "^4.6.1",
-				"meow": "^5.0.0",
-				"multimatch": "^2.1.0",
-				"open-editor": "^1.2.0",
-				"path-exists": "^3.0.0",
-				"pkg-conf": "^2.1.0",
-				"prettier": "^1.12.1",
-				"resolve-cwd": "^2.0.0",
-				"resolve-from": "^4.0.0",
-				"semver": "^5.5.0",
-				"slash": "^2.0.0",
-				"update-notifier": "^2.3.0",
-				"xo-init": "^0.7.0"
+				"arrify": "1.0.1",
+				"debug": "3.1.0",
+				"eslint": "4.19.1",
+				"eslint-config-prettier": "2.9.0",
+				"eslint-config-xo": "0.22.2",
+				"eslint-formatter-pretty": "1.3.0",
+				"eslint-plugin-ava": "4.5.1",
+				"eslint-plugin-import": "2.12.0",
+				"eslint-plugin-no-use-extend-native": "0.3.12",
+				"eslint-plugin-node": "6.0.1",
+				"eslint-plugin-prettier": "2.6.0",
+				"eslint-plugin-promise": "3.8.0",
+				"eslint-plugin-unicorn": "4.0.3",
+				"get-stdin": "6.0.0",
+				"globby": "8.0.1",
+				"has-flag": "3.0.0",
+				"lodash.isequal": "4.5.0",
+				"lodash.mergewith": "4.6.1",
+				"meow": "5.0.0",
+				"multimatch": "2.1.0",
+				"open-editor": "1.2.0",
+				"path-exists": "3.0.0",
+				"pkg-conf": "2.1.0",
+				"prettier": "1.13.5",
+				"resolve-cwd": "2.0.0",
+				"resolve-from": "4.0.0",
+				"semver": "5.5.0",
+				"slash": "2.0.0",
+				"update-notifier": "2.5.0",
+				"xo-init": "0.7.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -9489,9 +9498,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0",
-						"map-obj": "^2.0.0",
-						"quick-lru": "^1.0.0"
+						"camelcase": "4.1.0",
+						"map-obj": "2.0.0",
+						"quick-lru": "1.1.0"
 					}
 				},
 				"get-stdin": {
@@ -9506,13 +9515,13 @@
 					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
-						"fast-glob": "^2.0.2",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
+						"array-union": "1.0.2",
+						"dir-glob": "2.0.0",
+						"fast-glob": "2.2.2",
+						"glob": "7.1.2",
+						"ignore": "3.3.10",
+						"pify": "3.0.0",
+						"slash": "1.0.0"
 					},
 					"dependencies": {
 						"slash": {
@@ -9535,10 +9544,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"map-obj": {
@@ -9553,15 +9562,15 @@
 					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0",
-						"yargs-parser": "^10.0.0"
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.4.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0",
+						"yargs-parser": "10.0.0"
 					}
 				},
 				"parse-json": {
@@ -9570,8 +9579,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"path-type": {
@@ -9580,7 +9589,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -9589,9 +9598,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -9600,8 +9609,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
 					}
 				},
 				"redent": {
@@ -9610,8 +9619,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "^3.0.0",
-						"strip-indent": "^2.0.0"
+						"indent-string": "3.2.0",
+						"strip-indent": "2.0.0"
 					}
 				},
 				"resolve-from": {
@@ -9646,14 +9655,14 @@
 			"integrity": "sha512-mrrCKMu52vz0u2tiOl8DoG709pBtnSp58bb4/j58a4jeXjrb1gV7dxfOBjOlXitYtfW2QnlxxxfAojoFcpynDg==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.0",
-				"execa": "^0.9.0",
-				"has-yarn": "^1.0.0",
-				"minimist": "^1.1.3",
-				"path-exists": "^3.0.0",
-				"read-pkg-up": "^3.0.0",
-				"the-argv": "^1.0.0",
-				"write-pkg": "^3.1.0"
+				"arrify": "1.0.1",
+				"execa": "0.9.0",
+				"has-yarn": "1.0.0",
+				"minimist": "1.2.0",
+				"path-exists": "3.0.0",
+				"read-pkg-up": "3.0.0",
+				"the-argv": "1.0.0",
+				"write-pkg": "3.2.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -9662,13 +9671,13 @@
 					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -9677,10 +9686,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"minimist": {
@@ -9695,8 +9704,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"path-type": {
@@ -9705,7 +9714,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -9714,9 +9723,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -9725,8 +9734,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
 					}
 				}
 			}
@@ -9749,7 +9758,7 @@
 			"integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,59 +5,34 @@
 	"requires": true,
 	"dependencies": {
 		"@ava/babel-plugin-throws-helper": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-3.0.0.tgz",
+			"integrity": "sha512-mN9UolOs4WX09QkheU1ELkVy2WPnwonlO3XMdN8JF8fQqRVgVTR21xDbvEOUsbwz6Zwjq7ji9yzyjuXqDPalxg==",
 			"dev": true
 		},
 		"@ava/babel-preset-stage-4": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
-			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-2.0.0.tgz",
+			"integrity": "sha512-OWqMYeTSZ16AfLx0Vn0Uj7tcu+uMRlbKmks+DVCFlln7vomVsOtst+Oz+HCussDSFGpE+30VtHAUHLy6pLDpHQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"package-hash": "1.2.0"
-			},
-			"dependencies": {
-				"md5-hex": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
-					"requires": {
-						"md5-o-matic": "0.1.1"
-					}
-				},
-				"package-hash": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
-					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-					"dev": true,
-					"requires": {
-						"md5-hex": "1.3.0"
-					}
-				}
+				"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+				"@babel/plugin-transform-async-to-generator": "^7.0.0",
+				"@babel/plugin-transform-dotall-regex": "^7.0.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0"
 			}
 		},
 		"@ava/babel-preset-transform-test-files": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
-			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-4.0.1.tgz",
+			"integrity": "sha512-D7Z92B8Rgsj35JZveKJGwpUDuBKLiRKH6eyKpNmDHy7TJjr8y3VSDr3bUK+O456F3SkkBXrUihQuMrr39nWQhQ==",
 			"dev": true,
 			"requires": {
-				"@ava/babel-plugin-throws-helper": "2.0.0",
-				"babel-plugin-espower": "2.4.0"
+				"@ava/babel-plugin-throws-helper": "^3.0.0",
+				"babel-plugin-espower": "^3.0.1"
 			}
 		},
 		"@ava/write-file-atomic": {
@@ -66,197 +41,361 @@
 			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"slide": "1.1.6"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"slide": "^1.1.5"
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-			"integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.49"
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+			"integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helpers": "^7.2.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/template": "^7.2.2",
+				"@babel/traverse": "^7.2.2",
+				"@babel/types": "^7.2.2",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.10",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/generator": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
-			"integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
+			"integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.49",
-				"jsesc": "2.5.1",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-					"dev": true
-				}
+				"@babel/types": "^7.2.2",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.10",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-			"integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.49",
-				"@babel/template": "7.0.0-beta.49",
-				"@babel/types": "7.0.0-beta.49"
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-			"integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.49"
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
+			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/template": "^7.2.2",
+				"@babel/types": "^7.2.2",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-regex": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-			"integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "7.0.0-beta.49"
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.2.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.2.0.tgz",
+			"integrity": "sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.5",
+				"@babel/types": "^7.2.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-			"integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-			"integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+			"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==",
 			"dev": true
 		},
-		"@babel/template": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
-			"integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.49",
-				"@babel/parser": "7.0.0-beta.49",
-				"@babel/types": "7.0.0-beta.49",
-				"lodash": "4.17.10"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/plugin-syntax-async-generators": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-1L5mWLSvR76XYUQJXkd/EEQgjq8HHRP6lQuZTTg0VA4tTGPpGemmCdAfQIz1rzEuWAm+ecP8PyyEm30jC1eQCg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
+			"integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
+			"integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.1.3"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
+			"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/types": "^7.2.2"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
-			"integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.49",
-				"@babel/generator": "7.0.0-beta.49",
-				"@babel/helper-function-name": "7.0.0-beta.49",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.49",
-				"@babel/parser": "7.0.0-beta.49",
-				"@babel/types": "7.0.0-beta.49",
-				"debug": "3.1.0",
-				"globals": "11.7.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
-			},
-			"dependencies": {
-				"globals": {
-					"version": "11.7.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-					"dev": true
-				}
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.2.3",
+				"@babel/types": "^7.2.2",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.10"
 			}
 		},
 		"@babel/types": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
-			"integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+			"integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "2.0.0"
-			},
-			"dependencies": {
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
-				}
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.10",
+				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@concordance/react": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
-			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-2.0.0.tgz",
+			"integrity": "sha512-huLSkUuM2/P+U0uy2WwlKuixMsTODD8p4JVQBI4VKeopkiN0C7M3N9XYVawb4M+4spN5RrO/eLhk7KoQX6nsfA==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1"
-			}
-		},
-		"@ladjs/time-require": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
-			"integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "0.4.0",
-				"date-time": "0.1.1",
-				"pretty-ms": "0.2.2",
-				"text-table": "0.2.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "1.0.0",
-						"has-color": "0.1.7",
-						"strip-ansi": "0.1.1"
-					}
-				},
-				"pretty-ms": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-					"dev": true,
-					"requires": {
-						"parse-ms": "0.1.2"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-					"dev": true
-				}
+				"arrify": "^1.0.1"
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -265,65 +404,75 @@
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
 			"dev": true,
 			"requires": {
-				"call-me-maybe": "1.0.1",
-				"glob-to-regexp": "0.3.0"
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
 			}
 		},
 		"@nodelib/fs.stat": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
-			"integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
 		},
-		"@sinonjs/formatio": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+		"@sinonjs/commons": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
 			"dev": true,
 			"requires": {
-				"samsam": "1.3.0"
+				"type-detect": "4.0.8"
 			}
 		},
+		"@sinonjs/formatio": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+			"integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/samsam": "^2 || ^3"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+			"integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.0.2",
+				"array-from": "^2.1.1",
+				"lodash.get": "^4.4.2"
+			}
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true,
+			"optional": true
+		},
 		"acorn": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-			"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+			"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
 			"dev": true
 		},
 		"acorn-jsx": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-			"dev": true,
-			"requires": {
-				"acorn": "3.3.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-					"dev": true
-				}
-			}
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"dev": true
 		},
 		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+			"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
 			}
-		},
-		"ajv-keywords": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-			"dev": true
 		},
 		"ansi-align": {
 			"version": "2.0.0",
@@ -331,7 +480,40 @@
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"ansi-escapes": {
@@ -352,17 +534,35 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.2"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true,
+			"optional": true
+		},
+		"are-we-there-yet": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
@@ -371,22 +571,13 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
-			"requires": {
-				"arr-flatten": "1.1.0"
-			}
-		},
-		"arr-exclude": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 			"dev": true
 		},
 		"arr-flatten": {
@@ -402,9 +593,9 @@
 			"dev": true
 		},
 		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.0.3.tgz",
+			"integrity": "sha1-AZW7AMzM8nEQbv7kpHhkiLcYBxI=",
 			"dev": true
 		},
 		"array-find-index": {
@@ -413,25 +604,39 @@
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
 			"dev": true
 		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+			"dev": true
+		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
+			},
+			"dependencies": {
+				"array-uniq": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+					"dev": true
+				}
 			}
 		},
 		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
+			"integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==",
 			"dev": true
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
 		"arrify": {
@@ -441,10 +646,13 @@
 			"dev": true
 		},
 		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
 		},
 		"assert-plus": {
 			"version": "1.0.0",
@@ -456,6 +664,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
 		"async-each": {
@@ -471,119 +685,112 @@
 			"dev": true
 		},
 		"atob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
-			"dev": true
-		},
-		"auto-bind": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.1.tgz",
-			"integrity": "sha512-/W9yj1yKmBLwpexwAujeD9YHwYmRuWFGV8HWE7smQab797VeHa4/cnE2NFeDhA+E+5e/OGBI8763EhLjfZ/MXA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
 		"ava": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-0.25.0.tgz",
-			"integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-1.1.0.tgz",
+			"integrity": "sha512-DVUsqzheRu3P0olLgZVWekAmJmO/a8bseest+vTBEGTm/lbrRdAjggzy7Vsj1+C7SCUn8GRXrmjZi1zvqaWb/A==",
 			"dev": true,
 			"requires": {
-				"@ava/babel-preset-stage-4": "1.1.0",
-				"@ava/babel-preset-transform-test-files": "3.0.0",
-				"@ava/write-file-atomic": "2.2.0",
-				"@concordance/react": "1.0.0",
-				"@ladjs/time-require": "0.1.4",
-				"ansi-escapes": "3.1.0",
-				"ansi-styles": "3.2.1",
-				"arr-flatten": "1.1.0",
-				"array-union": "1.0.2",
-				"array-uniq": "1.0.3",
-				"arrify": "1.0.1",
-				"auto-bind": "1.2.1",
-				"ava-init": "0.2.1",
-				"babel-core": "6.26.3",
-				"babel-generator": "6.26.1",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"bluebird": "3.5.1",
-				"caching-transform": "1.0.1",
-				"chalk": "2.4.1",
-				"chokidar": "1.7.0",
-				"clean-stack": "1.3.0",
-				"clean-yaml-object": "0.1.0",
-				"cli-cursor": "2.1.0",
-				"cli-spinners": "1.3.1",
-				"cli-truncate": "1.1.0",
-				"co-with-promise": "4.6.0",
-				"code-excerpt": "2.1.1",
-				"common-path-prefix": "1.0.0",
-				"concordance": "3.0.0",
-				"convert-source-map": "1.5.1",
-				"core-assert": "0.2.1",
-				"currently-unhandled": "0.4.1",
-				"debug": "3.1.0",
-				"dot-prop": "4.2.0",
-				"empower-core": "0.6.2",
-				"equal-length": "1.0.1",
-				"figures": "2.0.0",
-				"find-cache-dir": "1.0.0",
-				"fn-name": "2.0.1",
-				"get-port": "3.2.0",
-				"globby": "6.1.0",
-				"has-flag": "2.0.0",
-				"hullabaloo-config-manager": "1.1.1",
-				"ignore-by-default": "1.0.1",
-				"import-local": "0.1.1",
-				"indent-string": "3.2.0",
-				"is-ci": "1.1.0",
-				"is-generator-fn": "1.0.0",
-				"is-obj": "1.0.1",
-				"is-observable": "1.1.0",
-				"is-promise": "2.1.0",
-				"last-line-stream": "1.0.0",
-				"lodash.clonedeepwith": "4.5.0",
-				"lodash.debounce": "4.0.8",
-				"lodash.difference": "4.5.0",
-				"lodash.flatten": "4.4.0",
-				"loud-rejection": "1.6.0",
-				"make-dir": "1.3.0",
-				"matcher": "1.1.1",
-				"md5-hex": "2.0.0",
-				"meow": "3.7.0",
-				"ms": "2.1.1",
-				"multimatch": "2.1.0",
-				"observable-to-promise": "0.5.0",
-				"option-chain": "1.0.0",
-				"package-hash": "2.0.0",
-				"pkg-conf": "2.1.0",
-				"plur": "2.1.2",
-				"pretty-ms": "3.2.0",
-				"require-precompiled": "0.1.0",
-				"resolve-cwd": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"semver": "5.5.0",
-				"slash": "1.0.0",
-				"source-map-support": "0.5.6",
-				"stack-utils": "1.0.1",
-				"strip-ansi": "4.0.0",
-				"strip-bom-buf": "1.0.0",
-				"supertap": "1.0.0",
-				"supports-color": "5.4.0",
-				"trim-off-newlines": "1.0.1",
-				"unique-temp-dir": "1.0.0",
-				"update-notifier": "2.5.0"
-			}
-		},
-		"ava-init": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
-			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-			"dev": true,
-			"requires": {
-				"arr-exclude": "1.0.0",
-				"execa": "0.7.0",
-				"has-yarn": "1.0.0",
-				"read-pkg-up": "2.0.0",
-				"write-pkg": "3.2.0"
+				"@ava/babel-preset-stage-4": "^2.0.0",
+				"@ava/babel-preset-transform-test-files": "^4.0.1",
+				"@ava/write-file-atomic": "^2.2.0",
+				"@babel/core": "^7.2.2",
+				"@babel/generator": "^7.2.2",
+				"@babel/plugin-syntax-async-generators": "^7.2.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+				"@concordance/react": "^2.0.0",
+				"ansi-escapes": "^3.1.0",
+				"ansi-styles": "^3.2.1",
+				"arr-flatten": "^1.1.0",
+				"array-union": "^1.0.1",
+				"array-uniq": "^2.0.0",
+				"arrify": "^1.0.0",
+				"bluebird": "^3.5.3",
+				"chalk": "^2.4.2",
+				"chokidar": "^2.0.4",
+				"chunkd": "^1.0.0",
+				"ci-parallel-vars": "^1.0.0",
+				"clean-stack": "^2.0.0",
+				"clean-yaml-object": "^0.1.0",
+				"cli-cursor": "^2.1.0",
+				"cli-truncate": "^1.1.0",
+				"code-excerpt": "^2.1.1",
+				"common-path-prefix": "^1.0.0",
+				"concordance": "^4.0.0",
+				"convert-source-map": "^1.6.0",
+				"currently-unhandled": "^0.4.1",
+				"debug": "^4.1.1",
+				"del": "^3.0.0",
+				"dot-prop": "^4.2.0",
+				"emittery": "^0.4.1",
+				"empower-core": "^1.2.0",
+				"equal-length": "^1.0.0",
+				"escape-string-regexp": "^1.0.5",
+				"esm": "^3.0.84",
+				"figures": "^2.0.0",
+				"find-up": "^3.0.0",
+				"get-port": "^4.1.0",
+				"globby": "^7.1.1",
+				"ignore-by-default": "^1.0.0",
+				"import-local": "^2.0.0",
+				"indent-string": "^3.2.0",
+				"is-ci": "^2.0.0",
+				"is-error": "^2.2.1",
+				"is-observable": "^1.1.0",
+				"is-plain-object": "^2.0.4",
+				"is-promise": "^2.1.0",
+				"lodash.clone": "^4.5.0",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.clonedeepwith": "^4.5.0",
+				"lodash.debounce": "^4.0.3",
+				"lodash.difference": "^4.3.0",
+				"lodash.flatten": "^4.2.0",
+				"loud-rejection": "^1.2.0",
+				"make-dir": "^1.3.0",
+				"matcher": "^1.1.1",
+				"md5-hex": "^2.0.0",
+				"meow": "^5.0.0",
+				"ms": "^2.1.1",
+				"multimatch": "^3.0.0",
+				"observable-to-promise": "^0.5.0",
+				"ora": "^3.0.0",
+				"package-hash": "^2.0.0",
+				"pkg-conf": "^2.1.0",
+				"plur": "^3.0.1",
+				"pretty-ms": "^4.0.0",
+				"require-precompiled": "^0.1.0",
+				"resolve-cwd": "^2.0.0",
+				"slash": "^2.0.0",
+				"source-map-support": "^0.5.10",
+				"stack-utils": "^1.0.2",
+				"strip-ansi": "^5.0.0",
+				"strip-bom-buf": "^1.0.0",
+				"supertap": "^1.0.0",
+				"supports-color": "^6.1.0",
+				"trim-off-newlines": "^1.0.1",
+				"trim-right": "^1.0.1",
+				"unique-temp-dir": "^1.0.0",
+				"update-notifier": "^2.5.0"
+			},
+			"dependencies": {
+				"package-hash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+					"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"lodash.flattendeep": "^4.4.0",
+						"md5-hex": "^2.0.0",
+						"release-zalgo": "^1.0.0"
+					}
+				}
 			}
 		},
 		"aws-sign2": {
@@ -593,493 +800,25 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 			"dev": true
-		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
-		"babel-core": {
-			"version": "6.26.3",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.1",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
-			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-					"dev": true
-				}
-			}
-		},
-		"babel-helper-builder-binary-assignment-operator-visitor": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
-			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-call-delegate": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
-			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-explode-assignable-expression": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
-			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-get-function-arity": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-hoist-variables": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helper-regex": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
-			}
-		},
-		"babel-helper-remap-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-helpers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-check-es2015-constants": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
 		},
 		"babel-plugin-espower": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
-			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz",
+			"integrity": "sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babylon": "6.18.0",
-				"call-matcher": "1.0.1",
-				"core-js": "2.5.7",
-				"espower-location-detector": "1.0.0",
-				"espurify": "1.8.0",
-				"estraverse": "4.2.0"
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"call-matcher": "^1.0.0",
+				"core-js": "^2.0.0",
+				"espower-location-detector": "^1.0.0",
+				"espurify": "^1.6.0",
+				"estraverse": "^4.1.1"
 			}
-		},
-		"babel-plugin-syntax-async-functions": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
-		},
-		"babel-plugin-syntax-exponentiation-operator": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
-		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
-		},
-		"babel-plugin-transform-async-to-generator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
-			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-destructuring": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-function-name": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
-			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
-			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-parameters": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
-			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-spread": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-sticky-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-es2015-unicode-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
-			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
-			}
-		},
-		"babel-plugin-transform-exponentiation-operator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
-			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
-			}
-		},
-		"babel-plugin-transform-strict-mode": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
-			}
-		},
-		"babel-register": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
-			"requires": {
-				"babel-core": "6.26.3",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.7",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.10",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
-			},
-			"dependencies": {
-				"source-map-support": {
-					"version": "0.4.18",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-					"dev": true,
-					"requires": {
-						"source-map": "0.5.7"
-					}
-				}
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "2.5.7",
-				"regenerator-runtime": "0.11.1"
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.10"
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "1.0.3"
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1093,13 +832,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1108,7 +847,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1117,7 +856,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1126,7 +865,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1135,45 +874,32 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
 		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"binary-extensions": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
 			"dev": true
 		},
 		"boxen": {
@@ -1182,20 +908,45 @@
 			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 			"dev": true,
 			"requires": {
-				"ansi-align": "2.0.0",
-				"camelcase": "4.1.0",
-				"chalk": "2.4.1",
-				"cli-boxes": "1.0.0",
-				"string-width": "2.1.1",
-				"term-size": "1.2.0",
-				"widest-line": "2.0.0"
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^2.0.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^1.2.0",
+				"widest-line": "^2.0.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -1205,19 +956,37 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"buf-compare": {
@@ -1227,9 +996,9 @@
 			"dev": true
 		},
 		"buffer-from": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
 		"builtin-modules": {
@@ -1244,68 +1013,27 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
-			}
-		},
-		"caching-transform": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-			"dev": true,
-			"requires": {
-				"md5-hex": "1.3.0",
-				"mkdirp": "0.5.1",
-				"write-file-atomic": "1.3.4"
-			},
-			"dependencies": {
-				"md5-hex": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
-					"requires": {
-						"md5-o-matic": "0.1.1"
-					}
-				},
-				"write-file-atomic": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
-					}
-				}
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			}
 		},
 		"call-matcher": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
+			"integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7",
-				"deep-equal": "1.0.1",
-				"espurify": "1.8.0",
-				"estraverse": "4.2.0"
+				"core-js": "^2.0.0",
+				"deep-equal": "^1.0.0",
+				"espurify": "^1.6.0",
+				"estraverse": "^4.0.0"
 			}
 		},
 		"call-me-maybe": {
@@ -1320,41 +1048,33 @@
 			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
 			"dev": true
 		},
-		"caller-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"dev": true,
-			"requires": {
-				"callsites": "0.2.0"
-			}
-		},
 		"callsites": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
 			"dev": true
 		},
 		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 			"dev": true
 		},
 		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 			"dev": true,
 			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
+				"camelcase": "^4.1.0",
+				"map-obj": "^2.0.0",
+				"quick-lru": "^1.0.0"
 			}
 		},
 		"capture-stack-trace": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
 			"dev": true
 		},
 		"caseless": {
@@ -1364,43 +1084,77 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.4.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"chardet": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
 		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
 			"dev": true,
 			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.2.4",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.2.2",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"lodash.debounce": "^4.0.8",
+				"normalize-path": "^2.1.1",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.5"
 			}
 		},
+		"chownr": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+			"dev": true,
+			"optional": true
+		},
+		"chunkd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
+			"integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==",
+			"dev": true
+		},
 		"ci-info": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"ci-parallel-vars": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz",
+			"integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==",
 			"dev": true
 		},
 		"circular-json": {
@@ -1415,10 +1169,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1427,14 +1181,8 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
 				}
 			}
 		},
@@ -1444,13 +1192,13 @@
 			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"clean-stack": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
+			"integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
 			"dev": true
 		},
 		"clean-yaml-object": {
@@ -1471,7 +1219,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -1480,14 +1228,91 @@
 			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
 			"dev": true
 		},
+		"cli-table3": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+			"integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+			"dev": true,
+			"requires": {
+				"colors": "^1.1.2",
+				"object-assign": "^4.1.0",
+				"string-width": "^2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
 		"cli-truncate": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
 			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
 			"dev": true,
 			"requires": {
-				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"slice-ansi": "^1.0.0",
+				"string-width": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"cli-width": {
@@ -1496,20 +1321,55 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
 		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
-		},
-		"co-with-promise": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
-			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
-				"pinkie-promise": "1.0.0"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
+		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
 		},
 		"code-excerpt": {
 			"version": "2.1.1",
@@ -1517,8 +1377,14 @@
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
 			"dev": true,
 			"requires": {
-				"convert-to-spaces": "1.0.2"
+				"convert-to-spaces": "^1.0.1"
 			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -1526,32 +1392,38 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color-convert": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"colors": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
 			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"common-path-prefix": {
@@ -1578,46 +1450,23 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
-			"requires": {
-				"buffer-from": "1.1.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"typedarray": "0.0.6"
-			}
-		},
 		"concordance": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
-			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-4.0.0.tgz",
+			"integrity": "sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==",
 			"dev": true,
 			"requires": {
-				"date-time": "2.1.0",
-				"esutils": "2.0.2",
-				"fast-diff": "1.1.2",
-				"function-name-support": "0.2.0",
-				"js-string-escape": "1.0.1",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.flattendeep": "4.4.0",
-				"lodash.merge": "4.6.1",
-				"md5-hex": "2.0.0",
-				"semver": "5.5.0",
-				"well-known-symbols": "1.0.0"
-			},
-			"dependencies": {
-				"date-time": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-					"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-					"dev": true,
-					"requires": {
-						"time-zone": "1.0.0"
-					}
-				}
+				"date-time": "^2.1.0",
+				"esutils": "^2.0.2",
+				"fast-diff": "^1.1.2",
+				"js-string-escape": "^1.0.1",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.flattendeep": "^4.4.0",
+				"lodash.islength": "^4.0.1",
+				"lodash.merge": "^4.6.1",
+				"md5-hex": "^2.0.0",
+				"semver": "^5.5.1",
+				"well-known-symbols": "^2.0.0"
 			}
 		},
 		"configstore": {
@@ -1626,13 +1475,19 @@
 			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "4.2.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.3.0",
-				"unique-string": "1.0.0",
-				"write-file-atomic": "2.3.0",
-				"xdg-basedir": "3.0.0"
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
 			}
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
 		},
 		"contains-path": {
 			"version": "0.1.0",
@@ -1641,10 +1496,13 @@
 			"dev": true
 		},
 		"convert-source-map": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-			"dev": true
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
 		},
 		"convert-to-spaces": {
 			"version": "1.0.2",
@@ -1664,14 +1522,14 @@
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
 			"dev": true,
 			"requires": {
-				"buf-compare": "1.0.1",
-				"is-error": "2.2.1"
+				"buf-compare": "^1.0.0",
+				"is-error": "^2.2.0"
 			}
 		},
 		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
+			"integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -1681,24 +1539,17 @@
 			"dev": true
 		},
 		"coveralls": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
-			"integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
+			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
 			"dev": true,
 			"requires": {
-				"js-yaml": "3.12.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.87.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
+				"growl": "~> 1.10.0",
+				"js-yaml": "^3.11.0",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.0",
+				"request": "^2.85.0"
 			}
 		},
 		"create-error-class": {
@@ -1707,7 +1558,7 @@
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"dev": true,
 			"requires": {
-				"capture-stack-trace": "1.0.0"
+				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -1716,9 +1567,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.3",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"crypto-random-string": {
@@ -1733,7 +1584,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"dashdash": {
@@ -1742,30 +1593,25 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"date-time": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-			"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-			"dev": true
-		},
-		"debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
 			"dev": true,
 			"requires": {
-				"ms": "2.0.0"
-			},
-			"dependencies": {
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
+				"time-zone": "^1.0.0"
+			}
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"dev": true,
+			"requires": {
+				"ms": "^2.1.1"
 			}
 		},
 		"decamelize": {
@@ -1780,8 +1626,16 @@
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
-				"decamelize": "1.2.0",
-				"map-obj": "1.0.1"
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
+				}
 			}
 		},
 		"decode-uri-component": {
@@ -1814,7 +1668,16 @@
 			"integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
 			"dev": true,
 			"requires": {
-				"core-assert": "0.2.1"
+				"core-assert": "^0.2.0"
+			}
+		},
+		"defaults": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.2"
 			}
 		},
 		"define-property": {
@@ -1823,8 +1686,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -1833,7 +1696,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1842,7 +1705,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1851,73 +1714,46 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
 		"del": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 			"dev": true,
 			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.1",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.6.2"
+				"globby": "^6.1.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"p-map": "^1.1.1",
+				"pify": "^3.0.0",
+				"rimraf": "^2.2.8"
 			},
 			"dependencies": {
 				"globby": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"arrify": "1.0.1",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "2.0.4"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -1928,14 +1764,25 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"detect-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true,
-			"requires": {
-				"repeating": "2.0.1"
-			}
+			"optional": true
+		},
+		"detect-indent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+			"dev": true
+		},
+		"detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+			"dev": true,
+			"optional": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -1944,24 +1791,12 @@
 			"dev": true
 		},
 		"dir-glob": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.1.tgz",
+			"integrity": "sha512-UN6X6XwRjllabfRhBdkVSo63uurJ8nSvMGrwl94EYVz6g+exhTV+yVSYk5VC/xl3MBFBTtC0J20uFKce4Brrng==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"path-type": "3.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "3.0.0"
-					}
-				}
+				"path-type": "^3.0.0"
 			}
 		},
 		"doctrine": {
@@ -1970,7 +1805,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2"
+				"esutils": "^2.0.2"
 			}
 		},
 		"dot-prop": {
@@ -1979,7 +1814,7 @@
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"duplexer3": {
@@ -1989,23 +1824,29 @@
 			"dev": true
 		},
 		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
+		"emittery": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
+			"integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
+			"dev": true
+		},
 		"empower-core": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
+			"integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
 			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
-				"core-js": "2.5.7"
+				"core-js": "^2.0.0"
 			}
 		},
 		"enhance-visitors": {
@@ -2014,7 +1855,7 @@
 			"integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.13.1"
 			}
 		},
 		"env-editor": {
@@ -2035,7 +1876,7 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es6-error": {
@@ -2050,56 +1891,83 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "4.19.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
+			"integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"babel-code-frame": "6.26.0",
-				"chalk": "2.4.1",
-				"concat-stream": "1.6.2",
-				"cross-spawn": "5.1.0",
-				"debug": "3.1.0",
-				"doctrine": "2.1.0",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "1.0.0",
-				"espree": "3.5.4",
-				"esquery": "1.0.1",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"functional-red-black-tree": "1.0.1",
-				"glob": "7.1.2",
-				"globals": "11.7.0",
-				"ignore": "3.3.10",
-				"imurmurhash": "0.1.4",
-				"inquirer": "3.3.0",
-				"is-resolvable": "1.1.0",
-				"js-yaml": "3.12.0",
-				"json-stable-stringify-without-jsonify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "7.0.0",
-				"progress": "2.0.0",
-				"regexpp": "1.1.0",
-				"require-uncached": "1.0.3",
-				"semver": "5.5.0",
-				"strip-ansi": "4.0.0",
-				"strip-json-comments": "2.0.1",
-				"table": "4.0.2",
-				"text-table": "0.2.0"
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.5.3",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^4.0.0",
+				"eslint-utils": "^1.3.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^5.0.0",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^6.1.0",
+				"js-yaml": "^3.12.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.5",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.1",
+				"semver": "^5.5.1",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "^2.0.1",
+				"table": "^5.0.2",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "11.7.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-					"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -2109,51 +1977,70 @@
 			"integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
 			"dev": true,
 			"requires": {
-				"lodash.get": "4.4.2",
-				"lodash.zip": "4.2.0"
+				"lodash.get": "^4.4.2",
+				"lodash.zip": "^4.2.0"
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
-			"integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.5.0.tgz",
+			"integrity": "sha512-LcZEoAY5lL3/H2NTFSeUl/z8X8oMea1IxLEIb5uDbRxPTdQeeT7oGpRWT6UwHXGcoRbYH0TZmfRsh8iXbpyW7A==",
 			"dev": true,
 			"requires": {
-				"get-stdin": "5.0.1"
-			},
-			"dependencies": {
-				"get-stdin": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-					"dev": true
-				}
+				"get-stdin": "^6.0.0"
 			}
 		},
 		"eslint-config-xo": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.22.2.tgz",
-			"integrity": "sha512-uaBSUTZK5qni9sfFyahLg2BCqdp6NAJAAPMLQNk87JI1Azixsc96tgT8beKU1Y8vDIwfOQhsdn53rTkPPfKW+w==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.26.0.tgz",
+			"integrity": "sha512-l+93kmBSNr5rMrsqwC6xVWsi8LI4He3z6jSk38e9bAkMNsVsQ8XYO+qzXfJFgFX4i/+hiTswyHtl+nDut9rPaA==",
 			"dev": true
 		},
 		"eslint-formatter-pretty": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
-			"integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-2.1.0.tgz",
+			"integrity": "sha512-JdiUvqJeSuxFE1aNa+jlmhzjEZq/U22qIBsNelXf5N4eyLuEBzoqTkEotdP7nqxFsx9O7NLpl3UFmKMEnt3w4Q==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "2.0.0",
-				"chalk": "2.4.1",
-				"log-symbols": "2.2.0",
-				"plur": "2.1.2",
-				"string-width": "2.1.1"
+				"ansi-escapes": "^3.1.0",
+				"chalk": "^2.1.0",
+				"eslint-rule-docs": "^1.1.5",
+				"log-symbols": "^2.0.0",
+				"plur": "^3.0.1",
+				"string-width": "^2.0.0",
+				"supports-hyperlinks": "^1.0.1"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-					"integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -2163,8 +2050,8 @@
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"resolve": "1.5.0"
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2190,8 +2077,8 @@
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"pkg-dir": "1.0.0"
+				"debug": "^2.6.8",
+				"pkg-dir": "^1.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2209,8 +2096,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"ms": {
@@ -2225,22 +2112,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -2249,43 +2121,96 @@
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					}
 				}
 			}
 		},
 		"eslint-plugin-ava": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.5.1.tgz",
-			"integrity": "sha512-V0+QZkTYoEXAp8fojaoD85orqNgGfyHWpwQEUqVIRGCRsX9BFnKbG2eX875NgciF3Aouq7smOZcLYqQKgAyH7w==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-5.1.1.tgz",
+			"integrity": "sha512-3N7geVdXTabpngQOl+ih1ejMbFOXCUYROnTIP66KAQoMcEAkPSXYc/Jwo/qC4zpRR7PXMuf5afMzTEBpyZmWzQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"deep-strict-equal": "0.2.0",
-				"enhance-visitors": "1.0.0",
-				"espree": "3.5.4",
-				"espurify": "1.8.0",
-				"import-modules": "1.1.0",
-				"multimatch": "2.1.0",
-				"pkg-up": "2.0.0"
+				"arrify": "^1.0.1",
+				"deep-strict-equal": "^0.2.0",
+				"enhance-visitors": "^1.0.0",
+				"esm": "^3.0.82",
+				"espree": "^4.0.0",
+				"espurify": "^1.8.1",
+				"import-modules": "^1.1.0",
+				"is-plain-object": "^2.0.4",
+				"multimatch": "^2.1.0",
+				"pkg-up": "^2.0.0"
+			},
+			"dependencies": {
+				"array-differ": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+					"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+					"dev": true
+				},
+				"espree": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+					"integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+					"dev": true,
+					"requires": {
+						"acorn": "^6.0.2",
+						"acorn-jsx": "^5.0.0",
+						"eslint-visitor-keys": "^1.0.0"
+					}
+				},
+				"multimatch": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+					"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+					"dev": true,
+					"requires": {
+						"array-differ": "^1.0.0",
+						"array-union": "^1.0.1",
+						"arrify": "^1.0.0",
+						"minimatch": "^3.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-es": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+			"integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+			"dev": true,
+			"requires": {
+				"eslint-utils": "^1.3.0",
+				"regexpp": "^2.0.1"
+			}
+		},
+		"eslint-plugin-eslint-comments": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.0.1.tgz",
+			"integrity": "sha512-7zU6gCulKVmfG3AZdnvDxzfHaGdvkA8tsLiKbneeI/TlVaulJsRzOyMCctH9QTobKVJ6LIsiJbrkSKkgcFLHxw==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5",
+				"ignore": "^3.3.8"
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz",
-			"integrity": "sha1-2tMXgSktZmSyUxf9BJ0uKy8CIF0=",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+			"integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
 			"dev": true,
 			"requires": {
-				"contains-path": "0.1.0",
-				"debug": "2.6.9",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.8",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "0.3.2",
-				"eslint-module-utils": "2.2.0",
-				"has": "1.0.3",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"read-pkg-up": "2.0.0",
-				"resolve": "1.8.1"
+				"eslint-import-resolver-node": "^0.3.1",
+				"eslint-module-utils": "^2.2.0",
+				"has": "^1.0.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.3",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.6.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2303,8 +2228,39 @@
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"dev": true,
 					"requires": {
-						"esutils": "2.0.2",
-						"isarray": "1.0.0"
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"ms": {
@@ -2313,87 +2269,185 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				},
-				"resolve": {
-					"version": "1.8.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"dev": true,
 					"requires": {
-						"path-parse": "1.0.5"
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
 					}
 				}
 			}
 		},
 		"eslint-plugin-no-use-extend-native": {
-			"version": "0.3.12",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-			"integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.4.0.tgz",
+			"integrity": "sha512-9W2747CwC7aTJknLKY6ftdzj3AZz8DSaa64zONOMIemxH7YRr0+hqrvsNtHK/v9DusPuMxM9y9hBnfHwzKFmww==",
 			"dev": true,
 			"requires": {
-				"is-get-set-prop": "1.0.0",
-				"is-js-type": "2.0.0",
-				"is-obj-prop": "1.0.0",
-				"is-proto-prop": "1.0.1"
+				"is-get-set-prop": "^1.0.0",
+				"is-js-type": "^2.0.0",
+				"is-obj-prop": "^1.0.0",
+				"is-proto-prop": "^2.0.0"
 			}
 		},
 		"eslint-plugin-node": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz",
+			"integrity": "sha512-ZjOjbjEi6jd82rIpFSgagv4CHWzG9xsQAVp1ZPlhRnnYxcTgENUVBvhYmkQ7GvT1QFijUSo69RaiOJKhMu6i8w==",
 			"dev": true,
 			"requires": {
-				"ignore": "3.3.10",
-				"minimatch": "3.0.4",
-				"resolve": "1.5.0",
-				"semver": "5.5.0"
+				"eslint-plugin-es": "^1.3.1",
+				"eslint-utils": "^1.3.1",
+				"ignore": "^5.0.2",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.4.tgz",
+					"integrity": "sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
-			"integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+			"integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
 			"dev": true,
 			"requires": {
-				"fast-diff": "1.1.2",
-				"jest-docblock": "21.2.0"
+				"prettier-linter-helpers": "^1.0.0"
 			}
 		},
 		"eslint-plugin-promise": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-			"integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+			"integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
 			"dev": true
 		},
 		"eslint-plugin-unicorn": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-4.0.3.tgz",
-			"integrity": "sha512-F1JMyd42hx4qGhIaVdOSbDyhcxPgTy4BOzctTCkV+hqebPBUOAQn1f5AhMK2LTyiqCmKiTs8huAErbLBSWKoCQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-7.0.0.tgz",
+			"integrity": "sha512-Tz2/2nUwT0qzYzHfOzpib6dltmwivdJd+Kf7GZ4e/xg4INCpVMevl1MKFNFv19n9+g2KMdC7yXgPHdUnXmtiBQ==",
 			"dev": true,
 			"requires": {
-				"clean-regexp": "1.0.0",
-				"eslint-ast-utils": "1.1.0",
-				"import-modules": "1.1.0",
-				"lodash.camelcase": "4.3.0",
-				"lodash.kebabcase": "4.1.1",
-				"lodash.snakecase": "4.1.1",
-				"lodash.upperfirst": "4.3.1",
-				"safe-regex": "1.1.0"
+				"clean-regexp": "^1.0.0",
+				"eslint-ast-utils": "^1.0.0",
+				"import-modules": "^1.1.0",
+				"lodash.camelcase": "^4.1.1",
+				"lodash.kebabcase": "^4.0.1",
+				"lodash.snakecase": "^4.0.1",
+				"lodash.upperfirst": "^4.2.0",
+				"safe-regex": "^2.0.1"
+			},
+			"dependencies": {
+				"safe-regex": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.1.tgz",
+					"integrity": "sha512-4tbOl0xq/cxbhEhdvxKaCZgzwOKeqt2tnHc2OPBkMsVdZ0s0C5oJwI6voRI9XzPSzeN35PECDNDK946x4d/0eA==",
+					"dev": true,
+					"requires": {
+						"regexp-tree": "~0.0.85"
+					}
+				}
 			}
 		},
+		"eslint-rule-docs": {
+			"version": "1.1.45",
+			"resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.45.tgz",
+			"integrity": "sha512-2UcgwUTHG4NC7EN2ACwMr3BJy8QtopbnZlTqDqYl+cv7xvNI6ZPkppzXfnK7syVM1MEM6cnjEHL2oZHj5dZKAw==",
+			"dev": true
+		},
 		"eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.1",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
+		},
+		"eslint-utils": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+			"dev": true
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
+		},
+		"esm": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.1.0.tgz",
+			"integrity": "sha512-r4Go7Wh7Wh0WPinRXeeM9PIajRsUdt8SAyki5R1obVc0+BwtqvtjbngVSSdXg0jCe2xZkY8hyBMx6q/uymUkPw==",
 			"dev": true
 		},
 		"espower-location-detector": {
@@ -2402,35 +2456,36 @@
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
 			"dev": true,
 			"requires": {
-				"is-url": "1.2.4",
-				"path-is-absolute": "1.0.1",
-				"source-map": "0.5.7",
-				"xtend": "4.0.1"
+				"is-url": "^1.2.1",
+				"path-is-absolute": "^1.0.0",
+				"source-map": "^0.5.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"espree": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+			"integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.7.1",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^6.0.2",
+				"acorn-jsx": "^5.0.0",
+				"eslint-visitor-keys": "^1.0.0"
 			}
 		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
 		"espurify": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
-			"integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+			"integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7"
+				"core-js": "^2.0.0"
 			}
 		},
 		"esquery": {
@@ -2439,7 +2494,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -2448,7 +2503,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -2469,153 +2524,30 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
-			"requires": {
-				"fill-range": "2.2.4"
-			}
-		},
-		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-			"dev": true
-		},
-		"extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
-			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
-					"requires": {
-						"is-plain-object": "2.0.4"
-					}
-				}
-			}
-		},
-		"external-editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"dev": true,
-			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.23",
-				"tmp": "0.0.33"
-			}
-		},
-		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"dev": true,
-			"requires": {
-				"is-extglob": "1.0.0"
-			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
-		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-			"dev": true
-		},
-		"fast-diff": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-			"dev": true
-		},
-		"fast-glob": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
-			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
-			"dev": true,
-			"requires": {
-				"@mrmlnc/readdir-enhanced": "2.2.1",
-				"@nodelib/fs.stat": "1.1.0",
-				"glob-parent": "3.1.0",
-				"is-glob": "4.0.0",
-				"merge2": "1.2.2",
-				"micromatch": "3.1.10"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2625,273 +2557,22 @@
 						"ms": "2.0.0"
 					}
 				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
-						}
+						"is-descriptor": "^0.1.0"
 					}
 				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
-					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
-							"requires": {
-								"is-extglob": "2.1.1"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"ms": {
@@ -2900,6 +2581,141 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
+			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+			"dev": true,
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"dev": true
+		},
+		"fast-glob": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+			"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+			"dev": true,
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.3",
+				"micromatch": "^3.1.10"
 			}
 		},
 		"fast-json-stable-stringify": {
@@ -2920,7 +2736,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -2929,15 +2745,9 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
-		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
 		},
 		"fill-keys": {
 			"version": "1.0.2",
@@ -2945,75 +2755,70 @@
 			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
 			"dev": true,
 			"requires": {
-				"is-object": "1.0.1",
-				"merge-descriptors": "1.0.1"
+				"is-object": "~1.0.1",
+				"merge-descriptors": "~1.0.0"
 			}
 		},
 		"fill-range": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "3.0.0",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"find-cache-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+			"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"make-dir": "1.3.0",
-				"pkg-dir": "2.0.0"
+				"commondir": "^1.0.1",
+				"make-dir": "^1.0.0",
+				"pkg-dir": "^3.0.0"
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^3.0.0"
 			}
 		},
 		"flat-cache": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
 			"dev": true,
 			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"graceful-fs": "^4.1.2",
+				"rimraf": "~2.6.2",
+				"write": "^0.2.1"
 			}
-		},
-		"fn-name": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
-			"requires": {
-				"for-in": "1.0.2"
-			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -3022,14 +2827,14 @@
 			"dev": true
 		},
 		"form-data": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fragment-cache": {
@@ -3038,7 +2843,17 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
+			}
+		},
+		"fs-minipass": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"minipass": "^2.2.1"
 			}
 		},
 		"fs.realpath": {
@@ -3048,598 +2863,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.6.tgz",
+			"integrity": "sha512-BalK54tfK0pMC0jQFb2oHn1nz7JNQD/2ex5pBnCHgBi2xG7VV0cAOGy2RS2VbCqUXx5/6obMrMcQTJ8yjcGzbg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.10.0",
-				"node-pre-gyp": "0.10.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-					"dev": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-					"dev": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-					"dev": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-					"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-					"dev": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-					"dev": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-					"dev": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "2.2.4"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-					"dev": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.21",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": "2.1.2"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-					"dev": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "1.1.11"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				},
-				"minipass": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
-					}
-				},
-				"minizlib": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "2.2.4"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-					"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
-					"dev": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.1.10",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"dev": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"dev": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-					"dev": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "0.5.1",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-					"dev": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-					"dev": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.1.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.1",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
-				},
-				"yallist": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-					"dev": true
-				}
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			}
 		},
 		"function-bind": {
@@ -3648,22 +2879,51 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"function-name-support": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
-			"dev": true
-		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
+		"gauge": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"get-caller-file": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
+		},
 		"get-port": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-4.1.0.tgz",
+			"integrity": "sha512-4/fqAYrzrzOiqDrdeZRKXGdTGgbkfTEumGlNQPeP6Jy8w0PzN9mzeNQ3XgHaTNie8pQ3hOUkrwlZt2Fzk5H9mA==",
 			"dev": true
 		},
 		"get-set-props": {
@@ -3673,9 +2933,9 @@
 			"dev": true
 		},
 		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 			"dev": true
 		},
 		"get-stream": {
@@ -3696,40 +2956,42 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
-			}
-		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"dev": true,
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
 			}
 		},
 		"glob-to-regexp": {
@@ -3744,48 +3006,34 @@
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 			"dev": true,
 			"requires": {
-				"ini": "1.3.5"
+				"ini": "^1.3.4"
 			}
 		},
 		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+			"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
 			"dev": true
 		},
 		"globby": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+			"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
 			"dev": true,
 			"requires": {
-				"array-union": "1.0.2",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"dir-glob": "^2.0.0",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
 			},
 			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
 					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "2.0.4"
-					}
 				}
 			}
 		},
@@ -3795,23 +3043,29 @@
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
-				"create-error-class": "3.0.2",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-redirect": "1.0.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.1",
-				"safe-buffer": "5.1.2",
-				"timed-out": "4.0.1",
-				"unzip-response": "2.0.1",
-				"url-parse-lax": "1.0.0"
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -3820,13 +3074,13 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -3835,29 +3089,21 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.1.1"
 			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
-		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-			"dev": true
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true,
+			"optional": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -3865,17 +3111,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			}
 		},
 		"has-values": {
@@ -3884,37 +3122,17 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -3929,25 +3147,14 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
 			"integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
-			"dev": true,
 			"requires": {
-				"is-stream": "1.1.0"
-			}
-		},
-		"home-or-tmp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
-			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"is-stream": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
 		},
 		"http-signature": {
@@ -3956,40 +3163,18 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
-			}
-		},
-		"hullabaloo-config-manager": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
-			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-			"dev": true,
-			"requires": {
-				"dot-prop": "4.2.0",
-				"es6-error": "4.1.1",
-				"graceful-fs": "4.1.11",
-				"indent-string": "3.2.0",
-				"json5": "0.5.1",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.clonedeepwith": "4.5.0",
-				"lodash.isequal": "4.5.0",
-				"lodash.merge": "4.6.1",
-				"md5-hex": "2.0.0",
-				"package-hash": "2.0.0",
-				"pkg-dir": "2.0.0",
-				"resolve-from": "3.0.0",
-				"safe-buffer": "5.1.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"ignore": {
@@ -4004,6 +3189,34 @@
 			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
 			"dev": true
 		},
+		"ignore-walk": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
+		},
+		"import-fresh": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+			"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				}
+			}
+		},
 		"import-lazy": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -4011,13 +3224,13 @@
 			"dev": true
 		},
 		"import-local": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
-			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^3.0.0",
+				"resolve-cwd": "^2.0.0"
 			}
 		},
 		"import-modules": {
@@ -4043,8 +3256,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -4060,40 +3273,71 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+			"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.2.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.10",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.0",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.10",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rxjs": "^6.1.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.0.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
 			}
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "1.3.1"
-			}
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"irregular-plurals": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
+			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
 			"dev": true
 		},
 		"is-accessor-descriptor": {
@@ -4102,7 +3346,18 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-arrayish": {
@@ -4117,7 +3372,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "1.11.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -4132,16 +3387,16 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-ci": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.1.3"
+				"ci-info": "^2.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -4150,7 +3405,18 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-descriptor": {
@@ -4159,9 +3425,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4170,21 +3436,6 @@
 					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
 					"dev": true
 				}
-			}
-		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
-			"requires": {
-				"is-primitive": "2.0.0"
 			}
 		},
 		"is-error": {
@@ -4200,31 +3451,19 @@
 			"dev": true
 		},
 		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
 		},
 		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
-		},
-		"is-generator-fn": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-			"dev": true
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
 		},
 		"is-get-set-prop": {
 			"version": "1.0.0",
@@ -4232,17 +3471,17 @@
 			"integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
 			"dev": true,
 			"requires": {
-				"get-set-props": "0.1.0",
-				"lowercase-keys": "1.0.1"
+				"get-set-props": "^0.1.0",
+				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-installed-globally": {
@@ -4251,8 +3490,8 @@
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 			"dev": true,
 			"requires": {
-				"global-dirs": "0.1.1",
-				"is-path-inside": "1.0.1"
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-js-type": {
@@ -4261,7 +3500,7 @@
 			"integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
 			"dev": true,
 			"requires": {
-				"js-types": "1.0.0"
+				"js-types": "^1.0.0"
 			}
 		},
 		"is-npm": {
@@ -4271,12 +3510,23 @@
 			"dev": true
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-obj": {
@@ -4291,8 +3541,8 @@
 			"integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "1.0.1",
-				"obj-props": "1.1.0"
+				"lowercase-keys": "^1.0.0",
+				"obj-props": "^1.0.0"
 			}
 		},
 		"is-object": {
@@ -4307,24 +3557,7 @@
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "1.2.0"
-			}
-		},
-		"is-odd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "4.0.0"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
-				}
+				"symbol-observable": "^1.1.0"
 			}
 		},
 		"is-path-cwd": {
@@ -4339,7 +3572,7 @@
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "1.0.1"
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-path-inside": {
@@ -4348,7 +3581,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
 			}
 		},
 		"is-plain-obj": {
@@ -4363,28 +3596,8 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
+				"isobject": "^3.0.1"
 			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
@@ -4393,25 +3606,19 @@
 			"dev": true
 		},
 		"is-proto-prop": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-1.0.1.tgz",
-			"integrity": "sha512-dkmgrJB7nfJhH1ySK1/Qn9xLPMv3ZNlPSAPoyUseD6DQzBF6YmbgQnoyy9OM8derNUlDVJlUGdCEhYbcCPfN5A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-2.0.0.tgz",
+			"integrity": "sha512-jl3NbQ/fGLv5Jhan4uX+Ge9ohnemqyblWVVCpAvtTQzNFvV2xhJq+esnkIbYQ9F1nITXoLfDDQLp7LBw/zzncg==",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "1.0.1",
-				"proto-props": "1.1.0"
+				"lowercase-keys": "^1.0.0",
+				"proto-props": "^2.0.0"
 			}
 		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-			"dev": true
-		},
-		"is-resolvable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
 			"dev": true
 		},
 		"is-retry-allowed": {
@@ -4423,8 +3630,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -4469,13 +3675,10 @@
 			"dev": true
 		},
 		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -4484,31 +3687,25 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-			"integrity": "sha512-yMSw5xLIbdaxiVXHk3amfNM2WeBxLrwH/BCyZ9HvA/fylwziAIJOG2rKqWyLqEJqwKT725vxxqidv+SyynnGAA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
 			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.2.0.tgz",
-			"integrity": "sha512-ozQGtlIw+/a/F3n6QwWiuuyRAPp64+g2GVsKYsIez0sgIEzkU5ZpL2uZ5pmAzbEJ82anlRaPlOQZzkRXspgJyg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+			"integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
 			"dev": true,
 			"requires": {
-				"@babel/generator": "7.0.0-beta.49",
-				"@babel/parser": "7.0.0-beta.49",
-				"@babel/template": "7.0.0-beta.49",
-				"@babel/traverse": "7.0.0-beta.49",
-				"@babel/types": "7.0.0-beta.49",
-				"istanbul-lib-coverage": "2.0.0",
-				"semver": "5.5.0"
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.1",
+				"semver": "^5.5.0"
 			}
-		},
-		"jest-docblock": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-			"dev": true
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -4517,9 +3714,9 @@
 			"dev": true
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
 		"js-types": {
@@ -4529,26 +3726,25 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"jsesc": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
 		"json-parse-better-errors": {
@@ -4564,9 +3760,9 @@
 			"dev": true
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -4582,10 +3778,13 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -4600,28 +3799,16 @@
 			}
 		},
 		"just-extend": {
-			"version": "1.1.27",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
 		},
 		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
-			"requires": {
-				"is-buffer": "1.1.6"
-			}
-		},
-		"last-line-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
-			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-			"dev": true,
-			"requires": {
-				"through2": "2.0.3"
-			}
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
 		},
 		"latest-version": {
 			"version": "3.1.0",
@@ -4629,7 +3816,16 @@
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 			"dev": true,
 			"requires": {
-				"package-json": "4.0.1"
+				"package-json": "^4.0.0"
+			}
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
+			"requires": {
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"lcov-parse": {
@@ -4644,8 +3840,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"line-column-path": {
@@ -4655,45 +3851,43 @@
 			"dev": true
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"strip-bom": "3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
+		},
+		"lodash.clone": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
 			"dev": true
 		},
 		"lodash.clonedeep": {
@@ -4741,6 +3935,12 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
+		},
+		"lodash.islength": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
+			"integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
 			"dev": true
 		},
 		"lodash.kebabcase": {
@@ -4791,23 +3991,14 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1"
+				"chalk": "^2.0.1"
 			}
 		},
 		"lolex": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
-			"integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+			"integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
 			"dev": true
-		},
-		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"dev": true,
-			"requires": {
-				"js-tokens": "3.0.2"
-			}
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
@@ -4815,8 +4006,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
@@ -4826,13 +4017,21 @@
 			"dev": true
 		},
 		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
 			}
 		},
 		"make-dir": {
@@ -4840,7 +4039,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"map-cache": {
@@ -4850,9 +4049,9 @@
 			"dev": true
 		},
 		"map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
 			"dev": true
 		},
 		"map-visit": {
@@ -4861,7 +4060,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
 		},
 		"matcher": {
@@ -4870,146 +4069,48 @@
 			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.4"
 			}
-		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-			"dev": true
 		},
 		"md5-hex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
 			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+			"dev": true,
 			"requires": {
-				"md5-o-matic": "0.1.1"
+				"md5-o-matic": "^0.1.1"
 			}
 		},
 		"md5-o-matic": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+			"dev": true
 		},
-		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "2.0.4"
-					}
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				}
+				"mimic-fn": "^1.0.0"
+			}
+		},
+		"meow": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+			"dev": true,
+			"requires": {
+				"camelcase-keys": "^4.0.0",
+				"decamelize-keys": "^1.0.0",
+				"loud-rejection": "^1.0.0",
+				"minimist-options": "^3.0.1",
+				"normalize-package-data": "^2.3.4",
+				"read-pkg-up": "^3.0.0",
+				"redent": "^2.0.0",
+				"trim-newlines": "^2.0.0",
+				"yargs-parser": "^10.0.0"
 			}
 		},
 		"merge-descriptors": {
@@ -5019,45 +4120,45 @@
 			"dev": true
 		},
 		"merge2": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
 			"dev": true
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			}
 		},
 		"mime-db": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"version": "1.37.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.18",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"version": "2.1.21",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.33.0"
+				"mime-db": "~1.37.0"
 			}
 		},
 		"mimic-fn": {
@@ -5072,13 +4173,13 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
 		"minimist-options": {
@@ -5087,8 +4188,28 @@
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"is-plain-obj": "1.1.0"
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
+			}
+		},
+		"minipass": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
+			}
+		},
+		"minizlib": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"minipass": "^2.2.1"
 			}
 		},
 		"mixin-deep": {
@@ -5097,8 +4218,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5107,7 +4228,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -5119,6 +4240,14 @@
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
 			}
 		},
 		"module-not-found-error": {
@@ -5134,15 +4263,15 @@
 			"dev": true
 		},
 		"multimatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-3.0.0.tgz",
+			"integrity": "sha512-22foS/gqQfANZ3o+W7ST2x25ueHDVNWl/b9OlGcLpy/iKxjCpvcNCM51YCenUi7Mt/jAjjqv8JwZRs8YP5sRjA==",
 			"dev": true,
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^2.0.3",
+				"array-union": "^1.0.2",
+				"arrify": "^1.0.1",
+				"minimatch": "^3.0.4"
 			}
 		},
 		"mute-stream": {
@@ -5152,50 +4281,29 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
 			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			}
 		},
 		"natural-compare": {
@@ -5204,17 +4312,92 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"needle": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+			"integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"debug": "^2.1.2",
+				"iconv-lite": "^0.4.4",
+				"sax": "^1.2.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"nise": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-			"integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+			"integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "2.0.0",
-				"just-extend": "1.1.27",
-				"lolex": "2.7.0",
-				"path-to-regexp": "1.7.0",
-				"text-encoding": "0.6.4"
+				"@sinonjs/formatio": "^3.1.0",
+				"just-extend": "^4.0.2",
+				"lolex": "^2.3.2",
+				"path-to-regexp": "^1.7.0",
+				"text-encoding": "^0.6.4"
+			},
+			"dependencies": {
+				"lolex": {
+					"version": "2.7.5",
+					"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+					"dev": true
+				}
+			}
+		},
+		"node-pre-gyp": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+			"integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"detect-libc": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"needle": "^2.2.1",
+				"nopt": "^4.0.1",
+				"npm-packlist": "^1.1.6",
+				"npmlog": "^4.0.2",
+				"rc": "^1.2.7",
+				"rimraf": "^2.6.1",
+				"semver": "^5.3.0",
+				"tar": "^4"
+			}
+		},
+		"nopt": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"abbrev": "1",
+				"osenv": "^0.1.4"
 			}
 		},
 		"normalize-package-data": {
@@ -5223,10 +4406,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.6.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.3"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -5235,7 +4418,25 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-bundled": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+			"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+			"dev": true,
+			"optional": true
+		},
+		"npm-packlist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+			"integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"ignore-walk": "^3.0.1",
+				"npm-bundled": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -5244,7 +4445,20 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
+			}
+		},
+		"npmlog": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -5254,323 +4468,141 @@
 			"dev": true
 		},
 		"nyc": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
-			"integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+			"integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
 			"dev": true,
 			"requires": {
-				"archy": "1.0.0",
-				"arrify": "1.0.1",
-				"caching-transform": "1.0.1",
-				"convert-source-map": "1.5.1",
-				"debug-log": "1.0.1",
-				"default-require-extensions": "1.0.0",
-				"find-cache-dir": "0.1.1",
-				"find-up": "2.1.0",
-				"foreground-child": "1.5.6",
-				"glob": "7.1.2",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "2.2.0",
-				"istanbul-lib-report": "1.1.3",
-				"istanbul-lib-source-maps": "1.2.5",
-				"istanbul-reports": "1.4.1",
-				"md5-hex": "1.3.0",
-				"merge-source-map": "1.1.0",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"resolve-from": "2.0.0",
-				"rimraf": "2.6.2",
-				"signal-exit": "3.0.2",
-				"spawn-wrap": "1.4.2",
-				"test-exclude": "4.2.1",
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^2.0.0",
+				"convert-source-map": "^1.6.0",
+				"debug-log": "^1.0.1",
+				"find-cache-dir": "^2.0.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.3",
+				"istanbul-lib-coverage": "^2.0.1",
+				"istanbul-lib-hook": "^2.0.1",
+				"istanbul-lib-instrument": "^3.0.0",
+				"istanbul-lib-report": "^2.0.2",
+				"istanbul-lib-source-maps": "^2.0.1",
+				"istanbul-reports": "^2.0.1",
+				"make-dir": "^1.3.0",
+				"merge-source-map": "^1.1.0",
+				"resolve-from": "^4.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^5.0.0",
+				"uuid": "^3.3.2",
 				"yargs": "11.1.0",
-				"yargs-parser": "8.1.0"
+				"yargs-parser": "^9.0.2"
 			},
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2",
-						"longest": "1.0.1",
-						"repeat-string": "1.6.1"
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-					"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+					"bundled": true,
 					"dev": true
 				},
 				"ansi-regex": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"bundled": true,
 					"dev": true
 				},
 				"append-transform": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-					"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+					"version": "1.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"default-require-extensions": "1.0.0"
+						"default-require-extensions": "^2.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-					"dev": true
-				},
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"arr-flatten": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-					"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
-					"dev": true
-				},
-				"arr-union": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"bundled": true,
 					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-					"dev": true
-				},
-				"assign-symbols": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+					"bundled": true,
 					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
-				},
-				"atob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-					"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+					"bundled": true,
 					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"bundled": true,
 					"dev": true
-				},
-				"base": {
-					"version": "0.11.2",
-					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-					"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
-					"dev": true,
-					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-							"dev": true
-						}
-					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
-					}
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
 					}
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+					"bundled": true,
 					"dev": true
 				},
-				"cache-base": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-					"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
-					"dev": true,
-					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
-					}
-				},
 				"caching-transform": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-					"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+					"version": "2.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-hex": "1.3.0",
-						"mkdirp": "0.5.1",
-						"write-file-atomic": "1.3.4"
+						"make-dir": "^1.0.0",
+						"md5-hex": "^2.0.0",
+						"package-hash": "^2.0.0",
+						"write-file-atomic": "^2.0.0"
 					}
 				},
 				"camelcase": {
 					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-					"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4",
-						"lazy-cache": "1.0.4"
-					}
-				},
-				"class-utils": {
-					"version": "0.3.6",
-					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-					"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
-					"dev": true,
-					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						}
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
 					}
 				},
 				"cliui": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					},
 					"dependencies": {
 						"wordwrap": {
 							"version": "0.0.2",
-							"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-							"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+							"bundled": true,
 							"dev": true,
 							"optional": true
 						}
@@ -5578,64 +4610,39 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"bundled": true,
 					"dev": true
-				},
-				"collection-visit": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-					"dev": true,
-					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
-					}
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-					"dev": true
-				},
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+					"bundled": true,
 					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"bundled": true,
 					"dev": true
 				},
 				"convert-source-map": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-					"dev": true
-				},
-				"copy-descriptor": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-					"dev": true
+					"version": "1.6.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.3",
-						"which": "1.3.1"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"debug": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -5643,1634 +4650,760 @@
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-					"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+					"bundled": true,
 					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-					"dev": true
-				},
-				"decode-uri-component": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+					"bundled": true,
 					"dev": true
 				},
 				"default-require-extensions": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-					"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+					"version": "2.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"strip-bom": "2.0.0"
-					}
-				},
-				"define-property": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-					"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
-					"dev": true,
-					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
-					},
-					"dependencies": {
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-							"dev": true
-						}
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"error-ex": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+					"version": "1.3.2",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
+				},
+				"es6-error": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					},
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-							"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
-								"lru-cache": "4.1.3",
-								"shebang-command": "1.2.0",
-								"which": "1.3.1"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
-					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"extend-shallow": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
-					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-							"dev": true,
-							"requires": {
-								"is-plain-object": "2.0.4"
-							}
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
-					"dev": true,
-					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-							"dev": true
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
 							}
 						}
 					}
 				},
 				"find-cache-dir": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+					"version": "2.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"commondir": "1.0.1",
-						"mkdirp": "0.5.1",
-						"pkg-dir": "1.0.0"
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
 					}
 				},
 				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"version": "3.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^3.0.0"
 					}
-				},
-				"for-in": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-					"dev": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
-					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-					"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"signal-exit": "3.0.2"
-					}
-				},
-				"fragment-cache": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-					"dev": true,
-					"requires": {
-						"map-cache": "0.2.2"
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"bundled": true,
 					"dev": true
 				},
 				"get-caller-file": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+					"version": "1.0.3",
+					"bundled": true,
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"get-value": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+					"bundled": true,
 					"dev": true
 				},
 				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+					"version": "7.1.3",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+					"bundled": true,
 					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
-					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-					"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"async": "1.5.2",
-						"optimist": "0.6.1",
-						"source-map": "0.4.4",
-						"uglify-js": "2.8.29"
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-							"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
-								"amdefine": "1.0.1"
+								"amdefine": ">=0.0.4"
 							}
 						}
 					}
 				},
-				"has-value": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-					"dev": true,
-					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
-					}
-				},
-				"has-values": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-					"dev": true,
-					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
+				"has-flag": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
 				},
 				"hosted-git-info": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-					"integrity": "sha1-IyNbKasjDFdqqw1PE/wEawsDgiI=",
+					"version": "2.7.1",
+					"bundled": true,
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+					"bundled": true,
 					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"bundled": true,
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+					"bundled": true,
 					"dev": true
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-							"dev": true
-						}
-					}
-				},
-				"is-extendable": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"bundled": true,
 					"dev": true
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				},
-				"is-odd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-					"integrity": "sha1-dkZiRnH9fqVYzNmieVGC8pWPGyQ=",
-					"dev": true,
-					"requires": {
-						"is-number": "4.0.0"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-							"integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
-							"dev": true
-						}
-					}
-				},
-				"is-plain-object": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-					"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
-					"dev": true,
-					"requires": {
-						"isobject": "3.0.1"
-					}
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
-				},
-				"is-utf8": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-					"dev": true
-				},
-				"is-windows": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-					"integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
-					"dev": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"bundled": true,
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"bundled": true,
 					"dev": true
 				},
 				"istanbul-lib-coverage": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-					"integrity": "sha1-99jy5CuX43/nlhFMsPnWi146Q0E=",
+					"version": "2.0.1",
+					"bundled": true,
 					"dev": true
 				},
 				"istanbul-lib-hook": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-					"integrity": "sha1-hTjZcDcss3FtU+VVI91UtVeo2Js=",
+					"version": "2.0.1",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"append-transform": "0.4.0"
+						"append-transform": "^1.0.0"
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
-					"integrity": "sha1-LfEhiMD6d5kMDSF20tC6M5QYglk=",
+					"version": "2.0.2",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"path-parse": "1.0.5",
-						"supports-color": "3.2.3"
-					},
-					"dependencies": {
-						"has-flag": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-							"dev": true
-						},
-						"supports-color": {
-							"version": "3.2.3",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-							"dev": true,
-							"requires": {
-								"has-flag": "1.0.0"
-							}
-						}
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-					"integrity": "sha1-/+a+Tnq4bTYD5CkNVJkLFFBvybE=",
+					"version": "2.0.1",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^2.0.1",
+						"make-dir": "^1.3.0",
+						"rimraf": "^2.6.2",
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"istanbul-reports": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.4.1.tgz",
-					"integrity": "sha1-Ty6OkoqnoF0dpsQn1AmLJlXsczQ=",
+					"version": "2.0.1",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"handlebars": "4.0.11"
+						"handlebars": "^4.0.11"
 					}
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
 					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-					"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"version": "4.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"version": "3.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
-					},
-					"dependencies": {
-						"path-exists": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-							"dev": true
-						}
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
+				},
+				"lodash.flattendeep": {
+					"version": "4.4.0",
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+					"bundled": true,
 					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-					"integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
-				"map-cache": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-					"dev": true
-				},
-				"map-visit": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+				"make-dir": {
+					"version": "1.3.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"object-visit": "1.0.1"
+						"pify": "^3.0.0"
 					}
 				},
 				"md5-hex": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"version": "2.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-					"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+					"bundled": true,
 					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-					"integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-							"dev": true
-						}
-					}
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+					"bundled": true,
 					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"version": "0.0.10",
+					"bundled": true,
 					"dev": true
-				},
-				"mixin-deep": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-					"integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
-					"dev": true,
-					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
-					},
-					"dependencies": {
-						"is-extendable": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-							"dev": true,
-							"requires": {
-								"is-plain-object": "2.0.4"
-							}
-						}
-					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
 					"dev": true
-				},
-				"nanomatch": {
-					"version": "1.2.9",
-					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-					"integrity": "sha1-h59xUMstq3pHElkGbBBO7m4Pp8I=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-							"dev": true
-						}
-					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-					"integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"path-key": "2.0.1"
+						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"bundled": true,
 					"dev": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true
-				},
-				"object-copy": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-					"dev": true,
-					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						}
-					}
-				},
-				"object-visit": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-					"dev": true,
-					"requires": {
-						"isobject": "3.0.1"
-					}
-				},
-				"object.pick": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-					"dev": true,
-					"requires": {
-						"isobject": "3.0.1"
-					}
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minimist": "0.0.8",
-						"wordwrap": "0.0.3"
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+					"bundled": true,
 					"dev": true
 				},
 				"p-limit": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-					"integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
+					"version": "2.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"version": "3.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^2.0.0"
 					}
 				},
 				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"version": "2.0.0",
+					"bundled": true,
 					"dev": true
+				},
+				"package-hash": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"lodash.flattendeep": "^4.4.0",
+						"md5-hex": "^2.0.0",
+						"release-zalgo": "^1.0.0"
+					}
 				},
 				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"version": "4.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
-				},
-				"pascalcase": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-					"dev": true
 				},
 				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-					"dev": true
-				},
-				"path-parse": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-					"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"version": "3.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"version": "3.0.0",
+					"bundled": true,
 					"dev": true
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "2.0.4"
-					}
 				},
 				"pkg-dir": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"version": "3.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-							"dev": true,
-							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
-							}
-						}
+						"find-up": "^3.0.0"
 					}
-				},
-				"posix-character-classes": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+					"bundled": true,
 					"dev": true
 				},
 				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"version": "3.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"version": "4.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-							"dev": true,
-							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
-							}
-						}
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
-				"regex-not": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-					"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+				"release-zalgo": {
+					"version": "1.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"es6-error": "^4.0.1"
 					}
-				},
-				"repeat-element": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+					"bundled": true,
 					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"bundled": true,
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"bundled": true,
 					"dev": true
 				},
 				"resolve-from": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-					"dev": true
-				},
-				"resolve-url": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-					"dev": true
-				},
-				"ret": {
-					"version": "0.1.15",
-					"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-					"integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+					"version": "4.0.0",
+					"bundled": true,
 					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-					"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"align-text": "0.1.4"
+						"align-text": "^0.1.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-					"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
-				"safe-regex": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-					"dev": true,
-					"requires": {
-						"ret": "0.1.15"
-					}
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true,
+					"dev": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
+					"bundled": true,
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"dev": true
-				},
-				"set-value": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-					"integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"shebang-regex": "1.0.0"
+						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"bundled": true,
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"dev": true
-				},
-				"slide": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-					"dev": true
-				},
-				"snapdragon": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-					"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
-					"dev": true,
-					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.2",
-						"use": "3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"snapdragon-node": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-					"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
-					"dev": true,
-					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-data-descriptor": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
-							"dev": true,
-							"requires": {
-								"kind-of": "6.0.2"
-							}
-						},
-						"is-descriptor": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
-							"dev": true,
-							"requires": {
-								"is-accessor-descriptor": "1.0.0",
-								"is-data-descriptor": "1.0.0",
-								"kind-of": "6.0.2"
-							}
-						},
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-							"dev": true
-						}
-					}
-				},
-				"snapdragon-util": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-					"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					}
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				},
-				"source-map-resolve": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-					"integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+					"bundled": true,
 					"dev": true,
-					"requires": {
-						"atob": "2.1.1",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
-					}
-				},
-				"source-map-url": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-					"dev": true
+					"optional": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
-					"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-					"integrity": "sha1-z/WOc6giRhe2Vhq9wyWG6gyCJIw=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"foreground-child": "1.5.6",
-						"mkdirp": "0.5.1",
-						"os-homedir": "1.0.2",
-						"rimraf": "2.6.2",
-						"signal-exit": "3.0.2",
-						"which": "1.3.1"
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-					"integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-					"integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k=",
+					"bundled": true,
 					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-					"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-					"integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc=",
+					"bundled": true,
 					"dev": true
-				},
-				"split-string": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-					"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "3.0.2"
-					}
-				},
-				"static-extend": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-					"dev": true,
-					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						}
-					}
 				},
 				"string-width": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+					"bundled": true,
 					"dev": true
 				},
+				"supports-color": {
+					"version": "5.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
 				"test-exclude": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-					"integrity": "sha1-36Ii8DSAvKaSB8pyizfXS0X3JPo=",
+					"version": "5.0.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "3.1.10",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
-					}
-				},
-				"to-object-path": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				},
-				"to-regex": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-					"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
-					"dev": true,
-					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"dev": true,
-					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"arrify": "^1.0.1",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
+						"require-main-filename": "^1.0.1"
 					}
 				},
 				"uglify-js": {
 					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "0.5.7",
-						"uglify-to-browserify": "1.0.2",
-						"yargs": "3.10.0"
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
 					},
 					"dependencies": {
 						"yargs": {
 							"version": "3.10.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"camelcase": "1.2.1",
-								"cliui": "2.1.0",
-								"decamelize": "1.2.0",
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
 								"window-size": "0.1.0"
 							}
 						}
@@ -7278,284 +5411,195 @@
 				},
 				"uglify-to-browserify": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-					"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
-				"union-value": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-					"dev": true,
-					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						},
-						"set-value": {
-							"version": "0.4.3",
-							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-							"dev": true,
-							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
-							}
-						}
-					}
-				},
-				"unset-value": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-					"dev": true,
-					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
-					},
-					"dependencies": {
-						"has-value": {
-							"version": "0.3.1",
-							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-							"dev": true,
-							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
-							},
-							"dependencies": {
-								"isobject": {
-									"version": "2.1.0",
-									"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-									"dev": true,
-									"requires": {
-										"isarray": "1.0.0"
-									}
-								}
-							}
-						},
-						"has-values": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-							"dev": true
-						}
-					}
-				},
-				"urix": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+				"uuid": {
+					"version": "3.3.2",
+					"bundled": true,
 					"dev": true
-				},
-				"use": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-					"integrity": "sha1-FHFr8D/f79AwQK71jYtLhfOnxUQ=",
-					"dev": true,
-					"requires": {
-						"kind-of": "6.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-							"dev": true
-						}
-					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-					"integrity": "sha1-gWQ7y+8b3+zUYjeT3EZIlIupgzg=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"which": {
 					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"isexe": "2.0.0"
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"bundled": true,
 					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"bundled": true,
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+							"bundled": true,
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "1.0.1"
+								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"ansi-regex": "^2.0.0"
 							}
 						}
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"bundled": true,
 					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"version": "2.3.0",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"bundled": true,
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"bundled": true,
 					"dev": true
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-					"integrity": "sha1-kLhpk07W6HERXqL/WLA/RyTtLXc=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cliui": "4.1.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "9.0.2"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					},
 					"dependencies": {
-						"camelcase": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-							"dev": true
-						},
 						"cliui": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-							"integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
-								"string-width": "2.1.1",
-								"strip-ansi": "4.0.0",
-								"wrap-ansi": "2.1.0"
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
 							}
 						},
-						"yargs-parser": {
-							"version": "9.0.2",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-							"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+						"find-up": {
+							"version": "2.1.0",
+							"bundled": true,
 							"dev": true,
 							"requires": {
-								"camelcase": "4.1.0"
+								"locate-path": "^2.0.0"
 							}
+						},
+						"locate-path": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "1.3.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-try": "^1.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-limit": "^1.1.0"
+							}
+						},
+						"p-try": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
+					"version": "9.0.2",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+							"bundled": true,
 							"dev": true
 						}
 					}
@@ -7563,9 +5607,9 @@
 			}
 		},
 		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
 		"obj-props": {
@@ -7586,9 +5630,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7597,7 +5641,16 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -7608,25 +5661,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
-			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"isobject": "^3.0.0"
 			}
 		},
 		"object.pick": {
@@ -7635,15 +5670,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
+				"isobject": "^3.0.1"
 			}
 		},
 		"observable-to-promise": {
@@ -7652,8 +5679,8 @@
 			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
 			"dev": true,
 			"requires": {
-				"is-observable": "0.2.0",
-				"symbol-observable": "1.2.0"
+				"is-observable": "^0.2.0",
+				"symbol-observable": "^1.0.4"
 			},
 			"dependencies": {
 				"is-observable": {
@@ -7662,7 +5689,7 @@
 					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 					"dev": true,
 					"requires": {
-						"symbol-observable": "0.2.4"
+						"symbol-observable": "^0.2.2"
 					},
 					"dependencies": {
 						"symbol-observable": {
@@ -7681,7 +5708,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -7690,7 +5717,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"open-editor": {
@@ -7699,25 +5726,19 @@
 			"integrity": "sha1-dcoj8LdNSz9V7guKTg9cIyXrd18=",
 			"dev": true,
 			"requires": {
-				"env-editor": "0.3.1",
-				"line-column-path": "1.0.0",
-				"opn": "5.3.0"
+				"env-editor": "^0.3.1",
+				"line-column-path": "^1.0.0",
+				"opn": "^5.0.0"
 			}
 		},
 		"opn": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
 			"dev": true,
 			"requires": {
-				"is-wsl": "1.1.0"
+				"is-wsl": "^1.1.0"
 			}
-		},
-		"option-chain": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-			"dev": true
 		},
 		"optionator": {
 			"version": "0.8.2",
@@ -7725,25 +5746,79 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			}
+		},
+		"ora": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-3.0.0.tgz",
+			"integrity": "sha512-LBS97LFe2RV6GJmXBi6OKcETKyklHNMV0xw7BtsVn2MlsgsydyZetSCbCANr+PFLmDyv4KV88nn0eCKza665Mg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.3.1",
+				"cli-cursor": "^2.1.0",
+				"cli-spinners": "^1.1.0",
+				"log-symbols": "^2.2.0",
+				"strip-ansi": "^4.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"dev": true,
+			"optional": true
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"dev": true,
+			"requires": {
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
+			}
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
+		},
+		"osenv": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -7752,38 +5827,44 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
 			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.3.0"
+				"p-limit": "^2.0.0"
 			}
 		},
+		"p-map": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
+		},
 		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
 			"dev": true
 		},
 		"package-hash": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
-			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+			"integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"lodash.flattendeep": "4.4.0",
-				"md5-hex": "2.0.0",
-				"release-zalgo": "1.0.0"
+				"graceful-fs": "^4.1.15",
+				"hasha": "^3.0.0",
+				"lodash.flattendeep": "^4.4.0",
+				"release-zalgo": "^1.0.0"
 			}
 		},
 		"package-json": {
@@ -7792,37 +5873,35 @@
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"dev": true,
 			"requires": {
-				"got": "6.7.1",
-				"registry-auth-token": "3.3.2",
-				"registry-url": "3.1.0",
-				"semver": "5.5.0"
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
 			}
 		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+		"parent-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"callsites": "^3.0.0"
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.2"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parse-ms": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-			"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.0.0.tgz",
+			"integrity": "sha512-AddiXFSLLCqj+tCRJ9MrUtHZB4DWojO3tk0NVZ+g5MaMQHF2+p2ktqxuoXyPFLljz/aUK0Nfhd/uGWnhXVXEyA==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -7862,9 +5941,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
 		"path-to-regexp": {
@@ -7885,20 +5964,12 @@
 			}
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "2.3.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
+				"pify": "^3.0.0"
 			}
 		},
 		"performance-now": {
@@ -7913,18 +5984,18 @@
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pinkie": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
 			"dev": true
 		},
 		"pinkie-promise": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "1.0.0"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-conf": {
@@ -7933,41 +6004,62 @@
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"load-json-file": "4.0.0"
+				"find-up": "^2.0.0",
+				"load-json-file": "^4.0.0"
 			},
 			"dependencies": {
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
 				}
 			}
 		},
 		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^3.0.0"
 			}
 		},
 		"pkg-up": {
@@ -7976,16 +6068,61 @@
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				}
 			}
 		},
 		"plur": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
+			"integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "1.4.0"
+				"irregular-plurals": "^2.0.0"
 			}
 		},
 		"pluralize": {
@@ -8012,40 +6149,29 @@
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
-		},
 		"prettier": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
-			"integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw==",
+			"version": "1.15.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+			"integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
 			"dev": true
 		},
-		"pretty-ms": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
-			"integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
 			"dev": true,
 			"requires": {
-				"parse-ms": "1.0.1"
-			},
-			"dependencies": {
-				"parse-ms": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-					"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-					"dev": true
-				}
+				"fast-diff": "^1.1.2"
 			}
 		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+		"pretty-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-4.0.0.tgz",
+			"integrity": "sha512-qG66ahoLCwpLXD09ZPHSCbUWYTqdosB7SMP4OffgTgL2PBKXMuUsrk5Bwg8q4qPkjTXsKBMr+YK3Ltd/6F9s/Q==",
+			"dev": true,
+			"requires": {
+				"parse-ms": "^2.0.0"
+			}
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -8054,26 +6180,37 @@
 			"dev": true
 		},
 		"progress": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
 		"proto-props": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proto-props/-/proto-props-1.1.0.tgz",
-			"integrity": "sha512-A377CdhQBRjYVsSWrm2jo0KJa+N/IBew6lGLm0pdzZjtVqlUT23wEqg7q1/bk5gBEgVoBBbaErZY+UUNrcKOug==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/proto-props/-/proto-props-2.0.0.tgz",
+			"integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
 			"dev": true
 		},
 		"proxyquire": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.1.tgz",
-			"integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
 			"dev": true,
 			"requires": {
-				"fill-keys": "1.0.2",
-				"module-not-found-error": "1.0.1",
-				"resolve": "1.5.0"
+				"fill-keys": "^1.0.2",
+				"module-not-found-error": "^1.0.0",
+				"resolve": "~1.8.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
 			}
 		},
 		"pseudomap": {
@@ -8082,10 +6219,16 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
+		"psl": {
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
 		"qs": {
@@ -8100,70 +6243,82 @@
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
 			"dev": true
 		},
-		"randomatic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-			"dev": true,
-			"requires": {
-				"is-number": "4.0.0",
-				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
-			}
-		},
 		"rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
 			"requires": {
-				"deep-extend": "0.6.0",
-				"ini": "1.3.5",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "2.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "2.0.0"
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "2.0.0"
+				"find-up": "^2.0.0",
+				"read-pkg": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				}
 			}
 		},
 		"readable-stream": {
@@ -8172,46 +6327,34 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.6",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 			"dev": true,
 			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "2.0.1"
-					}
-				}
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"regenerate": {
@@ -8220,19 +6363,13 @@
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
 			"dev": true
 		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+		"regenerate-unicode-properties": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"regenerate": "^1.4.0"
 			}
 		},
 		"regex-not": {
@@ -8241,25 +6378,39 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"regexp-tree": {
+			"version": "0.0.86",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.0.86.tgz",
+			"integrity": "sha512-xjTX9GmRw7Nn2wxinLoqQXv9Dt5yerP7CJIsYe/5z5gFs0Ltu20wRuZophafi9sf0JpsdVtki5EuICRYpgB1AQ==",
+			"dev": true,
+			"requires": {
+				"cli-table3": "^0.5.0",
+				"colors": "^1.1.2",
+				"yargs": "^10.0.3"
 			}
 		},
 		"regexpp": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
+			"integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.4.0",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^7.0.0",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.0.2"
 			}
 		},
 		"registry-auth-token": {
@@ -8268,8 +6419,8 @@
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.8",
-				"safe-buffer": "5.1.2"
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"registry-url": {
@@ -8278,22 +6429,30 @@
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.8"
+				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
 			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				}
 			}
 		},
 		"release-zalgo": {
@@ -8301,7 +6460,7 @@
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
 			"requires": {
-				"es6-error": "4.1.1"
+				"es6-error": "^4.0.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -8311,9 +6470,9 @@
 			"dev": true
 		},
 		"repeat-element": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
 			"dev": true
 		},
 		"repeat-string": {
@@ -8322,42 +6481,45 @@
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
 		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+		"request": {
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
-		"request": {
-			"version": "2.87.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.7.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.2.1"
-			}
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-precompiled": {
 			"version": "0.1.0",
@@ -8365,31 +6527,13 @@
 			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
 			"dev": true
 		},
-		"require-uncached": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"dev": true,
-			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-					"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-					"dev": true
-				}
-			}
-		},
 		"resolve": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+			"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-cwd": {
@@ -8398,7 +6542,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -8419,8 +6563,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
@@ -8430,12 +6574,12 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.1.3"
 			}
 		},
 		"run-async": {
@@ -8444,22 +6588,16 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+		"rxjs": {
+			"version": "6.3.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
 			"dev": true,
 			"requires": {
-				"rx-lite": "4.0.8"
+				"tslib": "^1.9.0"
 			}
 		},
 		"safe-buffer": {
@@ -8474,7 +6612,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"safer-buffer": {
@@ -8483,16 +6621,17 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
-		"samsam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-			"dev": true
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true,
+			"optional": true
 		},
 		"semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
 			"dev": true
 		},
 		"semver-diff": {
@@ -8501,7 +6640,7 @@
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 			"dev": true,
 			"requires": {
-				"semver": "5.5.0"
+				"semver": "^5.0.3"
 			}
 		},
 		"serialize-error": {
@@ -8510,10 +6649,10 @@
 			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
 			"dev": true
 		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
 		"set-value": {
@@ -8522,10 +6661,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -8534,7 +6673,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -8545,7 +6684,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -8560,24 +6699,35 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sinon": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
-			"integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
+			"integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "2.0.0",
-				"diff": "3.5.0",
-				"lodash.get": "4.4.2",
-				"lolex": "2.7.0",
-				"nise": "1.4.2",
-				"supports-color": "5.4.0",
-				"type-detect": "4.0.8"
+				"@sinonjs/commons": "^1.2.0",
+				"@sinonjs/formatio": "^3.1.0",
+				"@sinonjs/samsam": "^3.0.2",
+				"diff": "^3.5.0",
+				"lolex": "^3.0.0",
+				"nise": "^1.4.7",
+				"supports-color": "^5.5.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 			"dev": true
 		},
 		"slice-ansi": {
@@ -8586,7 +6736,15 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0"
+				"is-fullwidth-code-point": "^2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				}
 			}
 		},
 		"slide": {
@@ -8601,14 +6759,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.2",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -8626,7 +6784,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -8635,7 +6793,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"ms": {
@@ -8652,9 +6810,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8663,7 +6821,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -8672,7 +6830,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -8681,7 +6839,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -8690,22 +6848,10 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
 				}
 			}
 		},
@@ -8715,7 +6861,18 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"sort-keys": {
@@ -8724,7 +6881,7 @@
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-map": {
@@ -8739,21 +6896,21 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "2.1.1",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+			"version": "0.5.10",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+			"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.0",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -8771,19 +6928,19 @@
 			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
@@ -8792,14 +6949,14 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
 			"dev": true
 		},
 		"split-string": {
@@ -8808,7 +6965,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"sprintf-js": {
@@ -8818,26 +6975,26 @@
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+			"integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
 		"static-extend": {
@@ -8846,8 +7003,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8856,19 +7013,31 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
 			}
 		},
 		"string_decoder": {
@@ -8877,22 +7046,22 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+			"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0"
+				"ansi-regex": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
 					"dev": true
 				}
 			}
@@ -8909,7 +7078,7 @@
 			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.1"
 			}
 		},
 		"strip-eof": {
@@ -8919,13 +7088,10 @@
 			"dev": true
 		},
 		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "4.0.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -8939,27 +7105,71 @@
 			"integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"indent-string": "3.2.0",
-				"js-yaml": "3.12.0",
-				"serialize-error": "2.1.0",
-				"strip-ansi": "4.0.0"
+				"arrify": "^1.0.1",
+				"indent-string": "^3.2.0",
+				"js-yaml": "^3.10.0",
+				"serialize-error": "^2.1.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+			"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
+			}
+		},
+		"supports-hyperlinks": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+			"integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^2.0.0",
+				"supports-color": "^5.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+							"dev": true
+						}
+					}
 				}
 			}
 		},
@@ -8970,17 +7180,75 @@
 			"dev": true
 		},
 		"table": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
+			"integrity": "sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
-				"chalk": "2.4.1",
-				"lodash": "4.17.10",
-				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"ajv": "^6.6.1",
+				"lodash": "^4.17.11",
+				"slice-ansi": "2.0.0",
+				"string-width": "^2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"slice-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+					"integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"astral-regex": "^1.0.0",
+						"is-fullwidth-code-point": "^2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"tar": {
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"fs-minipass": "^1.2.5",
+				"minipass": "^2.3.4",
+				"minizlib": "^1.1.1",
+				"mkdirp": "^0.5.0",
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.2"
 			}
 		},
 		"term-size": {
@@ -8989,7 +7257,7 @@
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0"
+				"execa": "^0.7.0"
 			}
 		},
 		"text-encoding": {
@@ -9016,16 +7284,6 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
-		"through2": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "2.3.6",
-				"xtend": "4.0.1"
-			}
-		},
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
@@ -9044,13 +7302,13 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.2"
 			}
 		},
 		"to-fast-properties": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
 		"to-object-path": {
@@ -9059,7 +7317,18 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"to-regex": {
@@ -9068,10 +7337,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -9080,34 +7349,32 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				}
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			}
 		},
 		"tough-cookie": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				}
 			}
 		},
 		"trim-newlines": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
 			"dev": true
 		},
 		"trim-off-newlines": {
@@ -9122,21 +7389,26 @@
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -9144,7 +7416,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"type-detect": {
@@ -9153,16 +7425,38 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
-		"typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
-		},
 		"uid2": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
 			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+			"dev": true
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+			"dev": true
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"dev": true,
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+			"dev": true
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
 			"dev": true
 		},
 		"union-value": {
@@ -9171,10 +7465,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -9183,7 +7477,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
@@ -9192,10 +7486,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
@@ -9206,7 +7500,7 @@
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 			"dev": true,
 			"requires": {
-				"crypto-random-string": "1.0.0"
+				"crypto-random-string": "^1.0.0"
 			}
 		},
 		"unique-temp-dir": {
@@ -9215,8 +7509,8 @@
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1",
-				"os-tmpdir": "1.0.2",
+				"mkdirp": "^0.5.1",
+				"os-tmpdir": "^1.0.1",
 				"uid2": "0.0.3"
 			}
 		},
@@ -9226,8 +7520,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
@@ -9236,9 +7530,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -9257,12 +7551,6 @@
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
 					"dev": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
 				}
 			}
 		},
@@ -9272,22 +7560,54 @@
 			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
 			"dev": true
 		},
+		"upath": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"dev": true
+		},
 		"update-notifier": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
 			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 			"dev": true,
 			"requires": {
-				"boxen": "1.3.0",
-				"chalk": "2.4.1",
-				"configstore": "3.1.2",
-				"import-lazy": "2.1.0",
-				"is-ci": "1.1.0",
-				"is-installed-globally": "0.1.0",
-				"is-npm": "1.0.0",
-				"latest-version": "3.1.0",
-				"semver-diff": "2.1.0",
-				"xdg-basedir": "3.0.0"
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+					"dev": true
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"dev": true,
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
 			}
 		},
 		"urix": {
@@ -9302,25 +7622,14 @@
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"use": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"dev": true,
-			"requires": {
-				"kind-of": "6.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
-				}
-			}
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -9329,19 +7638,19 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"verror": {
@@ -9350,15 +7659,24 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
+			"requires": {
+				"defaults": "^1.0.3"
 			}
 		},
 		"well-known-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+			"integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
 			"dev": true
 		},
 		"which": {
@@ -9367,16 +7685,65 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
 			}
 		},
 		"widest-line": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"wordwrap": {
@@ -9384,6 +7751,27 @@
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -9397,7 +7785,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -9405,9 +7793,9 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"write-json-file": {
@@ -9416,20 +7804,12 @@
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 			"dev": true,
 			"requires": {
-				"detect-indent": "5.0.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.3.0",
-				"pify": "3.0.0",
-				"sort-keys": "2.0.0",
-				"write-file-atomic": "2.3.0"
-			},
-			"dependencies": {
-				"detect-indent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-					"dev": true
-				}
+				"detect-indent": "^5.0.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"sort-keys": "^2.0.0",
+				"write-file-atomic": "^2.0.0"
 			}
 		},
 		"write-pkg": {
@@ -9438,8 +7818,8 @@
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
 			"dev": true,
 			"requires": {
-				"sort-keys": "2.0.0",
-				"write-json-file": "2.3.0"
+				"sort-keys": "^2.0.0",
+				"write-json-file": "^2.2.0"
 			}
 		},
 		"xdg-basedir": {
@@ -9449,202 +7829,76 @@
 			"dev": true
 		},
 		"xo": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/xo/-/xo-0.21.1.tgz",
-			"integrity": "sha512-pQp9cMptNOm3Ru8Ks4M1lQmTidYmn0kPrlkJNM3mCDMMhpQgiBzEWtekeQP/qH+rmnV7aZZv2ttaK30TjTtpEQ==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.24.0.tgz",
+			"integrity": "sha512-eaXWpNtXHbJ+DSiDkdRnDcMYPeUi/MWFUoUgorBhzAueTCM+v4o9Xv6buYgyoL4r7JuTp5EWXx3lGn9Md4dgWA==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"debug": "3.1.0",
-				"eslint": "4.19.1",
-				"eslint-config-prettier": "2.9.0",
-				"eslint-config-xo": "0.22.2",
-				"eslint-formatter-pretty": "1.3.0",
-				"eslint-plugin-ava": "4.5.1",
-				"eslint-plugin-import": "2.12.0",
-				"eslint-plugin-no-use-extend-native": "0.3.12",
-				"eslint-plugin-node": "6.0.1",
-				"eslint-plugin-prettier": "2.6.0",
-				"eslint-plugin-promise": "3.8.0",
-				"eslint-plugin-unicorn": "4.0.3",
-				"get-stdin": "6.0.0",
-				"globby": "8.0.1",
-				"has-flag": "3.0.0",
-				"lodash.isequal": "4.5.0",
-				"lodash.mergewith": "4.6.1",
-				"meow": "5.0.0",
-				"multimatch": "2.1.0",
-				"open-editor": "1.2.0",
-				"path-exists": "3.0.0",
-				"pkg-conf": "2.1.0",
-				"prettier": "1.13.5",
-				"resolve-cwd": "2.0.0",
-				"resolve-from": "4.0.0",
-				"semver": "5.5.0",
-				"slash": "2.0.0",
-				"update-notifier": "2.5.0",
-				"xo-init": "0.7.0"
+				"arrify": "^1.0.1",
+				"debug": "^4.1.0",
+				"eslint": "^5.12.0",
+				"eslint-config-prettier": "^3.3.0",
+				"eslint-config-xo": "^0.26.0",
+				"eslint-formatter-pretty": "^2.0.0",
+				"eslint-plugin-ava": "^5.1.0",
+				"eslint-plugin-eslint-comments": "^3.0.1",
+				"eslint-plugin-import": "^2.14.0",
+				"eslint-plugin-no-use-extend-native": "^0.4.0",
+				"eslint-plugin-node": "^8.0.0",
+				"eslint-plugin-prettier": "^3.0.0",
+				"eslint-plugin-promise": "^4.0.0",
+				"eslint-plugin-unicorn": "^7.0.0",
+				"find-cache-dir": "^2.0.0",
+				"get-stdin": "^6.0.0",
+				"globby": "^9.0.0",
+				"has-flag": "^3.0.0",
+				"lodash.isequal": "^4.5.0",
+				"lodash.mergewith": "^4.6.1",
+				"meow": "^5.0.0",
+				"multimatch": "^3.0.0",
+				"open-editor": "^1.2.0",
+				"path-exists": "^3.0.0",
+				"pkg-conf": "^2.1.0",
+				"prettier": "^1.15.2",
+				"resolve-cwd": "^2.0.0",
+				"resolve-from": "^4.0.0",
+				"semver": "^5.5.0",
+				"slash": "^2.0.0",
+				"update-notifier": "^2.3.0",
+				"xo-init": "^0.7.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
-					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
-					}
-				},
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				},
 				"globby": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-9.0.0.tgz",
+					"integrity": "sha512-q0qiO/p1w/yJ0hk8V9x1UXlgsXUxlGd0AHUOXZVXBO6aznDtpx7M8D1kBrCAItoPm+4l8r6ATXV1JpjY2SBQOw==",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"dir-glob": "2.0.0",
-						"fast-glob": "2.2.2",
-						"glob": "7.1.2",
-						"ignore": "3.3.10",
-						"pify": "3.0.0",
-						"slash": "1.0.0"
-					},
-					"dependencies": {
-						"slash": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-							"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-							"dev": true
-						}
+						"array-union": "^1.0.2",
+						"dir-glob": "^2.2.1",
+						"fast-glob": "^2.2.6",
+						"glob": "^7.1.3",
+						"ignore": "^4.0.3",
+						"pify": "^4.0.1",
+						"slash": "^2.0.0"
 					}
 				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 					"dev": true
 				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
-				},
-				"meow": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0",
-						"yargs-parser": "10.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "3.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
-					}
-				},
-				"redent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
-					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
-					}
 				},
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"strip-indent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
-				},
-				"trim-newlines": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
 					"dev": true
 				}
 			}
@@ -9655,14 +7909,14 @@
 			"integrity": "sha512-mrrCKMu52vz0u2tiOl8DoG709pBtnSp58bb4/j58a4jeXjrb1gV7dxfOBjOlXitYtfW2QnlxxxfAojoFcpynDg==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"execa": "0.9.0",
-				"has-yarn": "1.0.0",
-				"minimist": "1.2.0",
-				"path-exists": "3.0.0",
-				"read-pkg-up": "3.0.0",
-				"the-argv": "1.0.0",
-				"write-pkg": "3.2.0"
+				"arrify": "^1.0.0",
+				"execa": "^0.9.0",
+				"has-yarn": "^1.0.0",
+				"minimist": "^1.1.3",
+				"path-exists": "^3.0.0",
+				"read-pkg-up": "^3.0.0",
+				"the-argv": "^1.0.0",
+				"write-pkg": "^3.1.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -9671,71 +7925,13 @@
 					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "1.3.2",
-						"json-parse-better-errors": "1.0.2"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "3.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				}
 			}
@@ -9746,27 +7942,130 @@
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 			"dev": true
 		},
-		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 			"dev": true
 		},
-		"yargs-parser": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
-			"integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
+		"yallist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^8.1.0"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
 				}
+			}
+		},
+		"yargs-parser": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^4.1.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
 	],
 	"dependencies": {
 		"make-dir": "^1.0.0",
-		"md5-hex": "^2.0.0",
 		"package-hash": "^2.0.0",
 		"write-file-atomic": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "^0.25.0",
 		"coveralls": "^3.0.1",
+		"hasha": "^3.0.0",
 		"nyc": "^12.0.2",
 		"proxyquire": "^2.0.1",
 		"rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"hash"
 	],
 	"dependencies": {
+		"hasha": "^3.0.0",
 		"make-dir": "^1.0.0",
 		"package-hash": "^2.0.0",
 		"write-file-atomic": "^2.0.0"
@@ -30,7 +31,6 @@
 	"devDependencies": {
 		"ava": "^0.25.0",
 		"coveralls": "^3.0.1",
-		"hasha": "^3.0.0",
 		"nyc": "^12.0.2",
 		"proxyquire": "^2.0.1",
 		"rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -24,18 +24,18 @@
 	],
 	"dependencies": {
 		"hasha": "^3.0.0",
-		"make-dir": "^1.0.0",
-		"package-hash": "^2.0.0",
-		"write-file-atomic": "^2.0.0"
+		"make-dir": "^1.3.0",
+		"package-hash": "^3.0.0",
+		"write-file-atomic": "^2.3.0"
 	},
 	"devDependencies": {
-		"ava": "^0.25.0",
-		"coveralls": "^3.0.1",
-		"nyc": "^12.0.2",
-		"proxyquire": "^2.0.1",
-		"rimraf": "^2.6.2",
-		"sinon": "^5.1.0",
-		"xo": "^0.21.1"
+		"ava": "^1.1.0",
+		"coveralls": "^3.0.2",
+		"nyc": "^13.1.0",
+		"proxyquire": "^2.1.0",
+		"rimraf": "^2.6.3",
+		"sinon": "^7.2.2",
+		"xo": "^0.24.0"
 	},
 	"nyc": {
 		"reporter": [

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Returns a transform callback that takes two arguments:
  - `input` a string to be transformed
  - `metadata` an arbitrary data object
 
-Both arguments are passed to the wrapped transform. Results are cached in the cache directory using an `md5` hash of `input` and an optional `salt` value. If a cache entry already exist for `input`, the wrapped transform function will never be called.
+Both arguments are passed to the wrapped transform. Results are cached in the cache directory using an `sha256` hash of `input` and an optional `salt` value. If a cache entry already exist for `input`, the wrapped transform function will never be called.
 
 #### options
 
@@ -65,7 +65,7 @@ Type: `Function(input: string|Buffer, metadata: *, hash: string): string|Buffer`
 
  - `input`: The value to be transformed. It is passed through from the wrapper.
  - `metadata`: An arbitrary data object passed through from the wrapper. A typical value might be a string filename.
- - `hash`: The salted hash of `input`. Useful if you intend to create additional cache entries beyond the transform result (i.e. `nyc` also creates cache entries for source-map data). This value is not available if the cache is disabled, if you still need it, the default can be computed via [`md5Hex([input, salt])`](https://www.npmjs.com/package/md5-hex).
+ - `hash`: The salted hash of `input`. Useful if you intend to create additional cache entries beyond the transform result (i.e. `nyc` also creates cache entries for source-map data). This value is not available if the cache is disabled, if you still need it, the default can be computed via [`hasha([input, salt])`](https://www.npmjs.com/package/hasha).
 
 The transform function will return a `string` (or Buffer if `encoding === 'buffer'`) containing the result of transforming `input`.
 


### PR DESCRIPTION
Removed md5-hex dependency for production by using node's
cryptp library.

Replaced md5-hex package with hasha for tests for ease of use.