### PR TITLE
Drop Node.js 6, add support for filenamePrefix callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ node_js:
   - "node"
   - 10
   - 8
-  - 6
 after_script:
   - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/index.js
+++ b/index.js
@@ -25,11 +25,13 @@ function wrap(opts) {
 		ext: '',
 		salt: '',
 		hashData: () => [],
+		filenamePrefix: () => '',
+		onHash: () => {},
 		...opts
 	};
 
 	let transformFn = opts.transform;
-	const {factory, cacheDir, shouldTransform, disableCache, hashData, onHash, ext, salt} = opts;
+	const {factory, cacheDir, shouldTransform, disableCache, hashData, onHash, filenamePrefix, ext, salt} = opts;
 	const cacheDirCreated = opts.createCacheDir === false;
 	let created = transformFn && cacheDirCreated;
 	const encoding = opts.encoding === 'buffer' ? undefined : opts.encoding || 'utf8';
@@ -66,11 +68,9 @@ function wrap(opts) {
 			...[].concat(hashData(input, metadata))
 		];
 		const hash = hasha(data, {algorithm: 'sha256'});
-		const cachedPath = path.join(cacheDir, hash + ext);
+		const cachedPath = path.join(cacheDir, filenamePrefix(metadata) + hash + ext);
 
-		if (onHash) {
-			onHash(input, metadata, hash);
-		}
+		onHash(input, metadata, hash);
 
 		try {
 			return fs.readFileSync(cachedPath, encoding);

--- a/index.js
+++ b/index.js
@@ -21,12 +21,17 @@ function wrap(opts) {
 		throw new Error('cacheDir must be a string');
 	}
 
+	opts = {
+		ext: '',
+		salt: '',
+		hashData: () => [],
+		...opts
+	};
+
 	let transformFn = opts.transform;
-	const {factory, cacheDir, shouldTransform, disableCache, hashData, onHash} = opts;
+	const {factory, cacheDir, shouldTransform, disableCache, hashData, onHash, ext, salt} = opts;
 	const cacheDirCreated = opts.createCacheDir === false;
 	let created = transformFn && cacheDirCreated;
-	const ext = opts.ext || '';
-	const salt = opts.salt || '';
 	const encoding = opts.encoding === 'buffer' ? undefined : opts.encoding || 'utf8';
 
 	function transform(input, metadata, hash) {
@@ -54,16 +59,12 @@ function wrap(opts) {
 			return transform(input, metadata);
 		}
 
-		let data = [ownHash || getOwnHash(), input];
-
-		if (salt) {
-			data.push(salt);
-		}
-
-		if (hashData) {
-			data = data.concat(hashData(input, metadata));
-		}
-
+		const data = [
+			ownHash || getOwnHash(),
+			input,
+			salt,
+			...[].concat(hashData(input, metadata))
+		];
 		const hash = hasha(data, {algorithm: 'sha256'});
 		const cachedPath = path.join(cacheDir, hash + ext);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
 			}
 		},
 		"@ava/babel-preset-transform-test-files": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-4.0.1.tgz",
-			"integrity": "sha512-D7Z92B8Rgsj35JZveKJGwpUDuBKLiRKH6eyKpNmDHy7TJjr8y3VSDr3bUK+O456F3SkkBXrUihQuMrr39nWQhQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-5.0.0.tgz",
+			"integrity": "sha512-rqgyQwkT0+j2JzYP51dOv80u33rzAvjBtXRzUON+7+6u26mjoudRXci2+1s18rat8r4uOlZfbzm114YS6pwmYw==",
 			"dev": true,
 			"requires": {
 				"@ava/babel-plugin-throws-helper": "^3.0.0",
@@ -56,18 +56,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.3.tgz",
-			"integrity": "sha512-w445QGI2qd0E0GlSnq6huRZWPMmQGCp5gd5ZWS4hagn0EiwzxD5QMFkpchyusAyVC1n27OKXzQ0/88aVU9n4xQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
+			"integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.3.3",
-				"@babel/helpers": "^7.2.0",
-				"@babel/parser": "^7.3.3",
-				"@babel/template": "^7.2.2",
-				"@babel/traverse": "^7.2.2",
-				"@babel/types": "^7.3.3",
+				"@babel/generator": "^7.4.4",
+				"@babel/helpers": "^7.4.4",
+				"@babel/parser": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -75,15 +75,23 @@
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.3.tgz",
-			"integrity": "sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+			"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.3",
+				"@babel/types": "^7.4.4",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
@@ -149,17 +157,17 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+			"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/template": "^7.2.2",
-				"@babel/types": "^7.2.2",
-				"lodash": "^4.17.10"
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -169,12 +177,12 @@
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+			"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -201,12 +209,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-wrap-function": {
@@ -222,14 +230,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
-			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+			"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.1.2",
-				"@babel/traverse": "^7.1.5",
-				"@babel/types": "^7.3.0"
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/highlight": {
@@ -244,9 +252,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.3.tgz",
-			"integrity": "sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+			"integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -261,9 +269,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
-			"integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+			"integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -308,9 +316,9 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
-			"integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+			"integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -319,14 +327,14 @@
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-			"integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
@@ -340,48 +348,48 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-			"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+			"integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0"
 			}
 		},
 		"@babel/template": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.2.2",
-				"@babel/types": "^7.2.2"
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+			"integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.2.2",
+				"@babel/generator": "^7.4.4",
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/parser": "^7.2.3",
-				"@babel/types": "^7.2.2",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/types": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.3.tgz",
-			"integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -415,27 +423,28 @@
 			"dev": true
 		},
 		"@sinonjs/commons": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+			"integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
 		},
 		"@sinonjs/formatio": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-			"integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+			"integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/samsam": "^2 || ^3"
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^3.1.0"
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.1.tgz",
-			"integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+			"integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.0.2",
@@ -443,10 +452,45 @@
 				"lodash": "^4.17.11"
 			}
 		},
+		"@sinonjs/text-encoding": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+			"dev": true
+		},
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
+		},
+		"@types/glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
+			"requires": {
+				"@types/events": "*",
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
+			"integrity": "sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==",
+			"dev": true
+		},
 		"acorn": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-			"integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+			"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -456,9 +500,9 @@
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.9.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-			"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -518,6 +562,21 @@
 				}
 			}
 		},
+		"append-transform": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^2.0.0"
+			}
+		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+			"dev": true
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -546,9 +605,9 @@
 			"dev": true
 		},
 		"array-differ": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.0.3.tgz",
-			"integrity": "sha1-AZW7AMzM8nEQbv7kpHhkiLcYBxI=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
+			"integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==",
 			"dev": true
 		},
 		"array-find-index": {
@@ -562,6 +621,16 @@
 			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
 			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
 			"dev": true
+		},
+		"array-includes": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.7.0"
+			}
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -581,9 +650,9 @@
 			}
 		},
 		"array-uniq": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
-			"integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+			"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
 			"dev": true
 		},
 		"array-unique": {
@@ -626,9 +695,9 @@
 			"dev": true
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -644,21 +713,21 @@
 			"dev": true
 		},
 		"ava": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-1.2.1.tgz",
-			"integrity": "sha512-EHqbPGdd8aNvlvRNL7liD1J9Auf9kByHj5Zi7zF7Z5ukn2ZStZgVBf7LSqirKIOWScB3XZzFQbO59SnTvzD5kA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-1.4.1.tgz",
+			"integrity": "sha512-wKpgOPTL7hJSBWpfbU4SA8rlsTZrph9g9g7qYDV7M6uK1rKeW8oCUJWRwCd8B24S4N0Y5myf6cTEnA66WIk0sA==",
 			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^2.0.0",
-				"@ava/babel-preset-transform-test-files": "^4.0.1",
+				"@ava/babel-preset-transform-test-files": "^5.0.0",
 				"@ava/write-file-atomic": "^2.2.0",
-				"@babel/core": "^7.2.2",
-				"@babel/generator": "^7.3.0",
+				"@babel/core": "^7.4.0",
+				"@babel/generator": "^7.4.0",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
 				"@concordance/react": "^2.0.0",
-				"ansi-escapes": "^3.1.0",
+				"ansi-escapes": "^3.2.0",
 				"ansi-styles": "^3.2.1",
 				"arr-flatten": "^1.1.0",
 				"array-union": "^1.0.1",
@@ -666,7 +735,7 @@
 				"arrify": "^1.0.0",
 				"bluebird": "^3.5.3",
 				"chalk": "^2.4.2",
-				"chokidar": "^2.0.4",
+				"chokidar": "^2.1.5",
 				"chunkd": "^1.0.0",
 				"ci-parallel-vars": "^1.0.0",
 				"clean-stack": "^2.0.0",
@@ -679,16 +748,16 @@
 				"convert-source-map": "^1.6.0",
 				"currently-unhandled": "^0.4.1",
 				"debug": "^4.1.1",
-				"del": "^3.0.0",
+				"del": "^4.0.0",
 				"dot-prop": "^4.2.0",
 				"emittery": "^0.4.1",
 				"empower-core": "^1.2.0",
 				"equal-length": "^1.0.0",
 				"escape-string-regexp": "^1.0.5",
-				"esm": "^3.1.3",
+				"esm": "^3.2.20",
 				"figures": "^2.0.0",
 				"find-up": "^3.0.0",
-				"get-port": "^4.1.0",
+				"get-port": "^4.2.0",
 				"globby": "^7.1.1",
 				"ignore-by-default": "^1.0.0",
 				"import-local": "^2.0.0",
@@ -705,24 +774,24 @@
 				"lodash.difference": "^4.3.0",
 				"lodash.flatten": "^4.2.0",
 				"loud-rejection": "^1.2.0",
-				"make-dir": "^1.3.0",
+				"make-dir": "^2.1.0",
 				"matcher": "^1.1.1",
 				"md5-hex": "^2.0.0",
 				"meow": "^5.0.0",
 				"ms": "^2.1.1",
 				"multimatch": "^3.0.0",
 				"observable-to-promise": "^0.5.0",
-				"ora": "^3.0.0",
+				"ora": "^3.2.0",
 				"package-hash": "^3.0.0",
-				"pkg-conf": "^2.1.0",
+				"pkg-conf": "^3.0.0",
 				"plur": "^3.0.1",
 				"pretty-ms": "^4.0.0",
 				"require-precompiled": "^0.1.0",
 				"resolve-cwd": "^2.0.0",
 				"slash": "^2.0.0",
-				"source-map-support": "^0.5.10",
+				"source-map-support": "^0.5.11",
 				"stack-utils": "^1.0.2",
-				"strip-ansi": "^5.0.0",
+				"strip-ansi": "^5.2.0",
 				"strip-bom-buf": "^1.0.0",
 				"supertap": "^1.0.0",
 				"supports-color": "^6.1.0",
@@ -732,19 +801,41 @@
 				"update-notifier": "^2.5.0"
 			},
 			"dependencies": {
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+				"hasha": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+					"integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"is-stream": "^1.0.1"
 					}
 				},
-				"pify": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"package-hash": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+					"integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.15",
+						"hasha": "^3.0.0",
+						"lodash.flattendeep": "^4.4.0",
+						"release-zalgo": "^1.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				}
 			}
@@ -847,15 +938,15 @@
 			}
 		},
 		"binary-extensions": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
 			"dev": true
 		},
 		"boxen": {
@@ -941,6 +1032,57 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"caching-transform": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
+			"integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+			"dev": true,
+			"requires": {
+				"hasha": "^3.0.0",
+				"make-dir": "^2.0.0",
+				"package-hash": "^3.0.0",
+				"write-file-atomic": "^2.4.2"
+			},
+			"dependencies": {
+				"hasha": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+					"integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+					"dev": true,
+					"requires": {
+						"is-stream": "^1.0.1"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"package-hash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+					"integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.15",
+						"hasha": "^3.0.0",
+						"lodash.flattendeep": "^4.4.0",
+						"release-zalgo": "^1.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
+			}
+		},
 		"call-matcher": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
@@ -966,9 +1108,9 @@
 			"dev": true
 		},
 		"callsites": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
 		"camelcase": {
@@ -1029,9 +1171,9 @@
 			"dev": true
 		},
 		"chokidar": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.1.tgz",
-			"integrity": "sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
+			"integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
@@ -1045,7 +1187,7 @@
 				"normalize-path": "^3.0.0",
 				"path-is-absolute": "^1.0.0",
 				"readdirp": "^2.2.1",
-				"upath": "^1.1.0"
+				"upath": "^1.1.1"
 			}
 		},
 		"chunkd": {
@@ -1099,9 +1241,9 @@
 			}
 		},
 		"clean-stack": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
-			"integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+			"integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
 			"dev": true
 		},
 		"clean-yaml-object": {
@@ -1126,21 +1268,10 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.1.0.tgz",
+			"integrity": "sha512-8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA==",
 			"dev": true
-		},
-		"cli-table3": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-			"integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
-			"dev": true,
-			"requires": {
-				"colors": "^1.1.2",
-				"object-assign": "^4.1.0",
-				"string-width": "^2.1.1"
-			}
 		},
 		"cli-truncate": {
 			"version": "1.1.0",
@@ -1226,12 +1357,6 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
-		"colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-			"dev": true
-		},
 		"combined-stream": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -1240,6 +1365,13 @@
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
+		},
+		"commander": {
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"dev": true,
+			"optional": true
 		},
 		"common-path-prefix": {
 			"version": "1.0.0",
@@ -1254,9 +1386,9 @@
 			"dev": true
 		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
 			"dev": true
 		},
 		"concat-map": {
@@ -1282,6 +1414,14 @@
 				"md5-hex": "^2.0.0",
 				"semver": "^5.5.1",
 				"well-known-symbols": "^2.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"configstore": {
@@ -1365,9 +1505,9 @@
 			"dev": true
 		},
 		"coveralls": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
-			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.3.tgz",
+			"integrity": "sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==",
 			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
@@ -1375,7 +1515,38 @@
 				"lcov-parse": "^0.0.10",
 				"log-driver": "^1.2.7",
 				"minimist": "^1.2.0",
-				"request": "^2.85.0"
+				"request": "^2.86.0"
+			}
+		},
+		"cp-file": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
+			"integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^2.0.0",
+				"nested-error-stacks": "^2.0.0",
+				"pify": "^4.0.1",
+				"safe-buffer": "^5.0.1"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"create-error-class": {
@@ -1497,6 +1668,15 @@
 				"core-assert": "^0.2.0"
 			}
 		},
+		"default-require-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^3.0.0"
+			}
+		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -1504,6 +1684,15 @@
 			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
 			}
 		},
 		"define-property": {
@@ -1548,17 +1737,18 @@
 			}
 		},
 		"del": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+			"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
 			"dev": true,
 			"requires": {
+				"@types/glob": "^7.1.1",
 				"globby": "^6.1.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"p-map": "^1.1.1",
-				"pify": "^3.0.0",
-				"rimraf": "^2.2.8"
+				"is-path-cwd": "^2.0.0",
+				"is-path-in-cwd": "^2.0.0",
+				"p-map": "^2.0.0",
+				"pify": "^4.0.1",
+				"rimraf": "^2.6.3"
 			},
 			"dependencies": {
 				"globby": {
@@ -1581,12 +1771,6 @@
 							"dev": true
 						}
 					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
 				}
 			}
 		},
@@ -1673,6 +1857,15 @@
 				"core-js": "^2.0.0"
 			}
 		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
 		"enhance-visitors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
@@ -1703,6 +1896,31 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -1715,9 +1933,9 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.14.0.tgz",
-			"integrity": "sha512-jrOhiYyENRrRnWlMYANlGZTqb89r2FuRT+615AabBoajhNjeh9ywDNlh2LU9vTqf0WYN+L3xdXuIi7xuj/tK9w==",
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+			"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -1726,7 +1944,7 @@
 				"cross-spawn": "^6.0.5",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
-				"eslint-scope": "^4.0.0",
+				"eslint-scope": "^4.0.3",
 				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
 				"espree": "^5.0.1",
@@ -1740,7 +1958,7 @@
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"inquirer": "^6.2.2",
-				"js-yaml": "^3.12.0",
+				"js-yaml": "^3.13.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
 				"lodash": "^4.17.11",
@@ -1775,6 +1993,12 @@
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				},
 				"strip-ansi": {
@@ -1856,9 +2080,9 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-			"integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+			"integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
@@ -1994,9 +2218,9 @@
 			}
 		},
 		"eslint-plugin-eslint-comments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.0.tgz",
-			"integrity": "sha512-yvukhLNPZGkwKWe4Zr8gXCl10zfsa2jTksdKVhU0sYrK/RsvUoJ2PUKe4OJOupl1nS0cWlz7XyH4LUEwejTyaQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.1.tgz",
+			"integrity": "sha512-GZDKhOFqJLKlaABX+kdoLskcTINMrVOWxGca54KcFb1QCPd0CLmqgAMRxkkUfGSmN+5NJUMGh7NGccIMcWPSfQ==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5",
@@ -2004,29 +2228,30 @@
 			},
 			"dependencies": {
 				"ignore": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
-					"integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.1.tgz",
+					"integrity": "sha512-DWjnQIFLenVrwyRCKZT+7a7/U4Cqgar4WG8V++K3hw+lrW1hc/SIwdiGmtxKCVACmHULTuGeBbHJmbwW7/sAvA==",
 					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
-			"integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
+			"version": "2.17.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz",
+			"integrity": "sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==",
 			"dev": true,
 			"requires": {
+				"array-includes": "^3.0.3",
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
 				"eslint-import-resolver-node": "^0.3.2",
-				"eslint-module-utils": "^2.3.0",
+				"eslint-module-utils": "^2.4.0",
 				"has": "^1.0.3",
 				"lodash": "^4.17.11",
 				"minimatch": "^3.0.4",
 				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.9.0"
+				"resolve": "^1.10.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2183,9 +2408,15 @@
 			},
 			"dependencies": {
 				"ignore": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
-					"integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.1.tgz",
+					"integrity": "sha512-DWjnQIFLenVrwyRCKZT+7a7/U4Cqgar4WG8V++K3hw+lrW1hc/SIwdiGmtxKCVACmHULTuGeBbHJmbwW7/sAvA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				}
 			}
@@ -2200,9 +2431,9 @@
 			}
 		},
 		"eslint-plugin-promise": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-			"integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.1.1.tgz",
+			"integrity": "sha512-faAHw7uzlNPy7b45J1guyjazw28M+7gJokKUjC5JSFoYfUEyy6Gw/i7YQvmv2Yk00sUjWcmzXQLpU1Ki/C2IZQ==",
 			"dev": true
 		},
 		"eslint-plugin-unicorn": {
@@ -2222,26 +2453,26 @@
 			},
 			"dependencies": {
 				"safe-regex": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.1.tgz",
-					"integrity": "sha512-4tbOl0xq/cxbhEhdvxKaCZgzwOKeqt2tnHc2OPBkMsVdZ0s0C5oJwI6voRI9XzPSzeN35PECDNDK946x4d/0eA==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.2.tgz",
+					"integrity": "sha512-rRALJT0mh4qVFIJ9HvfjKDN77F9vp7kltOpFFI/8e6oKyHFmmxz4aSkY/YVauRDe7U0RrHdw9Lsxdel3E19s0A==",
 					"dev": true,
 					"requires": {
-						"regexp-tree": "~0.0.85"
+						"regexp-tree": "~0.1.1"
 					}
 				}
 			}
 		},
 		"eslint-rule-docs": {
-			"version": "1.1.62",
-			"resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.62.tgz",
-			"integrity": "sha512-yypzgi+ufomwZpCfGcIjsB/0rbF6VOmkOtCYTLFFO/8wPWgRD6G/csNsCO6+xx2/RHyX6qLcrTMakMdfJz/BTw==",
+			"version": "1.1.105",
+			"resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.105.tgz",
+			"integrity": "sha512-62+4LJ4Gu1QFf3AwYm7GXRebr0d+w7YspaPzGS8gjEH0EbLmjsUzfdwuAU0Xjs1Vt0xXUanMeXT2wO8u1MQauw==",
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+			"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
@@ -2261,9 +2492,9 @@
 			"dev": true
 		},
 		"esm": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.5.tgz",
-			"integrity": "sha512-rukU6Nd3agbHQCJWV4rrlZxqpbO3ix8qhUxK1BhKALGS2E465O0BFwgCOqJjNnYfO/I2MwpUBmPsW8DXoe8tcA==",
+			"version": "3.2.22",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.22.tgz",
+			"integrity": "sha512-z8YG7U44L82j1XrdEJcqZOLUnjxco8pO453gKOlaMD1/md1n/5QrscAmYG+oKUspsmDLuBFZrpbxI6aQ67yRxA==",
 			"dev": true
 		},
 		"espower-location-detector": {
@@ -2598,29 +2829,30 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-			"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
+				"make-dir": "^2.0.0",
 				"pkg-dir": "^3.0.0"
 			},
 			"dependencies": {
 				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
 					}
 				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				}
 			}
@@ -2657,6 +2889,28 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
+		"foreground-child": {
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				}
+			}
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2690,14 +2944,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "^2.12.1",
+				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2709,7 +2963,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2730,12 +2985,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2750,17 +3007,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2769,12 +3029,12 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
@@ -2877,7 +3137,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2889,6 +3150,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2903,6 +3165,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2910,12 +3173,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2934,29 +3199,30 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.4",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^4.1.0",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.3",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2984,13 +3250,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.5",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.2.0",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3014,7 +3280,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3026,6 +3293,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3111,7 +3379,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3126,7 +3395,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.6.0",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3147,6 +3416,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3166,6 +3436,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3209,12 +3480,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -3231,15 +3504,15 @@
 			"dev": true
 		},
 		"get-caller-file": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
 		"get-port": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-port/-/get-port-4.1.0.tgz",
-			"integrity": "sha512-4/fqAYrzrzOiqDrdeZRKXGdTGgbkfTEumGlNQPeP6Jy8w0PzN9mzeNQ3XgHaTNie8pQ3hOUkrwlZt2Fzk5H9mA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+			"integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
 			"dev": true
 		},
 		"get-set-props": {
@@ -3326,9 +3599,9 @@
 			}
 		},
 		"globals": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
 		},
 		"globby": {
@@ -3389,6 +3662,26 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
+		"handlebars": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3418,6 +3711,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
 			"dev": true
 		},
 		"has-value": {
@@ -3459,11 +3758,12 @@
 			"dev": true
 		},
 		"hasha": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-			"integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
+			"integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
 			"requires": {
-				"is-stream": "^1.0.1"
+				"is-stream": "^1.1.0",
+				"type-fest": "^0.3.0"
 			}
 		},
 		"hosted-git-info": {
@@ -3578,9 +3878,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-			"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+			"integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
@@ -3594,14 +3894,14 @@
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
 				"string-width": "^2.1.0",
-				"strip-ansi": "^5.0.0",
+				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			}
 		},
 		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 			"dev": true
 		},
 		"irregular-plurals": {
@@ -3651,6 +3951,12 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
 		"is-ci": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -3680,6 +3986,12 @@
 				}
 			}
 		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -3700,9 +4012,9 @@
 			}
 		},
 		"is-error": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
+			"integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
 			"dev": true
 		},
 		"is-extendable": {
@@ -3734,9 +4046,9 @@
 			}
 		},
 		"is-glob": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
@@ -3750,6 +4062,17 @@
 			"requires": {
 				"global-dirs": "^0.1.0",
 				"is-path-inside": "^1.0.0"
+			},
+			"dependencies": {
+				"is-path-inside": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+					"dev": true,
+					"requires": {
+						"path-is-inside": "^1.0.1"
+					}
+				}
 			}
 		},
 		"is-js-type": {
@@ -3819,27 +4142,27 @@
 			}
 		},
 		"is-path-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.1.0.tgz",
+			"integrity": "sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw==",
 			"dev": true
 		},
 		"is-path-in-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "^2.1.0"
 			}
 		},
 		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "^1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -3879,6 +4202,15 @@
 			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
 			"dev": true
 		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -3889,6 +4221,15 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -3945,24 +4286,108 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+			"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
 			"dev": true
 		},
-		"istanbul-lib-instrument": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+		"istanbul-lib-hook": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+			"integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
 			"dev": true,
 			"requires": {
-				"@babel/generator": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"@babel/template": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@babel/types": "^7.0.0",
-				"istanbul-lib-coverage": "^2.0.3",
-				"semver": "^5.5.0"
+				"append-transform": "^1.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.4.0",
+				"@babel/parser": "^7.4.3",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0",
+				"istanbul-lib-coverage": "^2.0.5",
+				"semver": "^6.0.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"rimraf": "^2.6.3",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz",
+			"integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
+			"dev": true,
+			"requires": {
+				"handlebars": "^4.1.2"
 			}
 		},
 		"js-string-escape": {
@@ -3984,9 +4409,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -4078,12 +4503,12 @@
 			}
 		},
 		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "^2.0.0"
 			}
 		},
 		"lcov-parse": {
@@ -4261,9 +4686,9 @@
 			}
 		},
 		"lolex": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
-			"integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
+			"integrity": "sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==",
 			"dev": true
 		},
 		"loud-rejection": {
@@ -4293,12 +4718,20 @@
 			}
 		},
 		"make-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.0.0.tgz",
-			"integrity": "sha512-DCZvJtCxpfY3a0Onp57Jm0PY9ggZENfVtBMsPdXFZDrMSHU5kYCMJkJesLr0/UrFdJKuDUYoGxCpc93n4F3Z8g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+			"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
 			"requires": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
+				"semver": "^6.0.0"
+			}
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
 			}
 		},
 		"map-cache": {
@@ -4347,12 +4780,22 @@
 			"dev": true
 		},
 		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				}
 			}
 		},
 		"meow": {
@@ -4377,6 +4820,23 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
 			"dev": true
+		},
+		"merge-source-map": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+			"integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+			"dev": true,
+			"requires": {
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
 		},
 		"merge2": {
 			"version": "1.2.3",
@@ -4406,18 +4866,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.22",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.38.0"
+				"mime-db": "1.40.0"
 			}
 		},
 		"mimic-fn": {
@@ -4520,9 +4980,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
 			"dev": true,
 			"optional": true
 		},
@@ -4551,6 +5011,18 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"nested-error-stacks": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+			"integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+			"dev": true
+		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -4558,16 +5030,16 @@
 			"dev": true
 		},
 		"nise": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
-			"integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+			"integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/formatio": "^3.1.0",
+				"@sinonjs/text-encoding": "^0.7.1",
 				"just-extend": "^4.0.2",
 				"lolex": "^2.3.2",
-				"path-to-regexp": "^1.7.0",
-				"text-encoding": "^0.6.4"
+				"path-to-regexp": "^1.7.0"
 			},
 			"dependencies": {
 				"lolex": {
@@ -4588,6 +5060,14 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-path": {
@@ -4612,1031 +5092,70 @@
 			"dev": true
 		},
 		"nyc": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
-			"integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.0.tgz",
+			"integrity": "sha512-iy9fEV8Emevz3z/AanIZsoGa8F4U2p0JKevZ/F0sk+/B2r9E6Qn+EPs0bpxEhnAt6UPlTL8mQZIaSJy8sK0ZFw==",
 			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
-				"arrify": "^1.0.1",
-				"caching-transform": "^3.0.1",
+				"caching-transform": "^3.0.2",
 				"convert-source-map": "^1.6.0",
-				"find-cache-dir": "^2.0.0",
+				"cp-file": "^6.2.0",
+				"find-cache-dir": "^2.1.0",
 				"find-up": "^3.0.0",
 				"foreground-child": "^1.5.6",
 				"glob": "^7.1.3",
-				"istanbul-lib-coverage": "^2.0.3",
-				"istanbul-lib-hook": "^2.0.3",
-				"istanbul-lib-instrument": "^3.1.0",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.2",
-				"istanbul-reports": "^2.1.1",
-				"make-dir": "^1.3.0",
+				"istanbul-lib-coverage": "^2.0.5",
+				"istanbul-lib-hook": "^2.0.7",
+				"istanbul-lib-instrument": "^3.3.0",
+				"istanbul-lib-report": "^2.0.8",
+				"istanbul-lib-source-maps": "^3.0.6",
+				"istanbul-reports": "^2.2.4",
+				"js-yaml": "^3.13.1",
+				"make-dir": "^2.1.0",
 				"merge-source-map": "^1.1.0",
 				"resolve-from": "^4.0.0",
 				"rimraf": "^2.6.3",
 				"signal-exit": "^3.0.2",
 				"spawn-wrap": "^1.4.2",
-				"test-exclude": "^5.1.0",
+				"test-exclude": "^5.2.3",
 				"uuid": "^3.3.2",
-				"yargs": "^12.0.5",
-				"yargs-parser": "^11.1.1"
+				"yargs": "^13.2.2",
+				"yargs-parser": "^13.0.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"append-transform": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"default-require-extensions": "^2.0.0"
-					}
-				},
-				"archy": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"arrify": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"async": {
-					"version": "2.6.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"lodash": "^4.17.11"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"caching-transform": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hasha": "^3.0.0",
-						"make-dir": "^1.3.0",
-						"package-hash": "^3.0.0",
-						"write-file-atomic": "^2.3.0"
-					}
-				},
 				"camelcase": {
-					"version": "5.0.0",
-					"bundled": true,
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"commander": {
-					"version": "2.17.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"commondir": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"convert-source-map": {
-					"version": "1.6.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"cross-spawn": {
-					"version": "4.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"default-require-extensions": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"end-of-stream": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"once": "^1.4.0"
-					}
-				},
-				"error-ex": {
-					"version": "1.3.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-arrayish": "^0.2.1"
-					}
-				},
-				"es6-error": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"execa": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					},
-					"dependencies": {
-						"cross-spawn": {
-							"version": "6.0.5",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"nice-try": "^1.0.4",
-								"path-key": "^2.0.1",
-								"semver": "^5.5.0",
-								"shebang-command": "^1.2.0",
-								"which": "^1.2.9"
-							}
-						}
-					}
-				},
-				"find-cache-dir": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^1.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"foreground-child": {
-					"version": "1.5.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^4",
-						"signal-exit": "^3.0.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.15",
-					"bundled": true,
-					"dev": true
-				},
-				"handlebars": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"async": "^2.5.0",
-						"optimist": "^0.6.1",
-						"source-map": "^0.6.1",
-						"uglify-js": "^3.1.4"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.6.1",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"hasha": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-stream": "^1.0.1"
-					}
-				},
-				"hosted-git-info": {
-					"version": "2.7.1",
-					"bundled": true,
-					"dev": true
-				},
-				"imurmurhash": {
-					"version": "0.1.4",
-					"bundled": true,
-					"dev": true
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-arrayish": {
-					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"istanbul-lib-coverage": {
-					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"istanbul-lib-hook": {
-					"version": "2.0.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"append-transform": "^1.0.0"
-					}
-				},
-				"istanbul-lib-report": {
-					"version": "2.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"istanbul-lib-coverage": "^2.0.3",
-						"make-dir": "^1.3.0",
-						"supports-color": "^6.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "6.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"istanbul-lib-source-maps": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"debug": "^4.1.1",
-						"istanbul-lib-coverage": "^2.0.3",
-						"make-dir": "^1.3.0",
-						"rimraf": "^2.6.2",
-						"source-map": "^0.6.1"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.6.1",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"istanbul-reports": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"handlebars": "^4.1.0"
-					}
-				},
-				"json-parse-better-errors": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.11",
-					"bundled": true,
-					"dev": true
-				},
-				"lodash.flattendeep": {
-					"version": "4.4.0",
-					"bundled": true,
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
 				},
 				"make-dir": {
-					"version": "1.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"map-age-cleaner": {
-					"version": "0.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-defer": "^1.0.0"
-					}
-				},
-				"mem": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^1.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"merge-source-map": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"source-map": "^0.6.1"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.6.1",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"mimic-fn": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.10",
-					"bundled": true,
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"nice-try": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "2.5.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"resolve": "^1.10.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"npm-run-path": {
-					"version": "2.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-key": "^2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"optimist": {
-					"version": "0.6.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "~0.0.1",
-						"wordwrap": "~0.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
-				"p-defer": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-finally": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-is-promise": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"p-limit": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"package-hash": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.15",
-						"hasha": "^3.0.0",
-						"lodash.flattendeep": "^4.4.0",
-						"release-zalgo": "^1.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				},
-				"pseudomap": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"pump": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"release-zalgo": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"es6-error": "^4.0.1"
-					}
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.10.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
 					}
 				},
 				"resolve-from": {
 					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
 				},
 				"semver": {
-					"version": "5.6.0",
-					"bundled": true,
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^1.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"spawn-wrap": {
-					"version": "1.4.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"foreground-child": "^1.5.6",
-						"mkdirp": "^0.5.0",
-						"os-homedir": "^1.0.1",
-						"rimraf": "^2.6.2",
-						"signal-exit": "^3.0.2",
-						"which": "^1.3.0"
-					}
-				},
-				"spdx-correct": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-exceptions": {
-					"version": "2.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"spdx-expression-parse": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-license-ids": {
-					"version": "3.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"strip-eof": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"test-exclude": {
-					"version": "5.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"arrify": "^1.0.1",
-						"minimatch": "^3.0.4",
-						"read-pkg-up": "^4.0.0",
-						"require-main-filename": "^1.0.1"
-					}
-				},
-				"uglify-js": {
-					"version": "3.4.9",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"commander": "~2.17.1",
-						"source-map": "~0.6.1"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.6.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"uuid": {
-					"version": "3.3.2",
-					"bundled": true,
-					"dev": true
-				},
-				"validate-npm-package-license": {
-					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
-					}
-				},
-				"which": {
-					"version": "1.3.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"wordwrap": {
-					"version": "0.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						}
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"write-file-atomic": {
-					"version": "2.4.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
 				},
 				"yargs-parser": {
-					"version": "11.1.1",
-					"bundled": true,
+					"version": "13.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
+					"integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -5693,6 +5212,12 @@
 					}
 				}
 			}
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -5771,12 +5296,30 @@
 			}
 		},
 		"opn": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+			"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
 			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
 			}
 		},
 		"optionator": {
@@ -5791,31 +5334,90 @@
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
 				"wordwrap": "~1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
 			}
 		},
 		"ora": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-3.1.0.tgz",
-			"integrity": "sha512-vRBPaNCclUi8pUxRF/G8+5qEQkc6EgzKK1G2ZNJUIGu088Un5qIxFXeDgymvPRM9nmrcUOGzQgS1Vmtz+NtlMw==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+			"integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
 				"cli-cursor": "^2.1.0",
-				"cli-spinners": "^1.3.1",
+				"cli-spinners": "^2.0.0",
 				"log-symbols": "^2.2.0",
-				"strip-ansi": "^5.0.0",
+				"strip-ansi": "^5.2.0",
 				"wcwidth": "^1.0.1"
 			}
 		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"os-tmpdir": {
@@ -5824,16 +5426,28 @@
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 			"dev": true
 		},
-		"p-limit": {
+		"p-is-promise": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-			"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
@@ -5849,24 +5463,24 @@
 			}
 		},
 		"p-map": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
 			"dev": true
 		},
 		"p-try": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
 		"package-hash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-			"integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
 			"requires": {
 				"graceful-fs": "^4.1.15",
-				"hasha": "^3.0.0",
+				"hasha": "^5.0.0",
 				"lodash.flattendeep": "^4.4.0",
 				"release-zalgo": "^1.0.0"
 			}
@@ -5881,12 +5495,20 @@
 				"registry-auth-token": "^3.0.1",
 				"registry-url": "^3.0.3",
 				"semver": "^5.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"parent-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
@@ -5903,9 +5525,9 @@
 			}
 		},
 		"parse-ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.0.0.tgz",
-			"integrity": "sha512-AddiXFSLLCqj+tCRJ9MrUtHZB4DWojO3tk0NVZ+g5MaMQHF2+p2ktqxuoXyPFLljz/aUK0Nfhd/uGWnhXVXEyA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -5993,7 +5615,8 @@
 		"pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -6011,57 +5634,27 @@
 			}
 		},
 		"pkg-conf": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+			"integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.0.0",
-				"load-json-file": "^4.0.0"
+				"find-up": "^3.0.0",
+				"load-json-file": "^5.2.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+				"load-json-file": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+					"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"graceful-fs": "^4.1.15",
+						"parse-json": "^4.0.0",
+						"pify": "^4.0.1",
+						"strip-bom": "^3.0.0",
+						"type-fest": "^0.3.0"
 					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
 				}
 			}
 		},
@@ -6129,9 +5722,9 @@
 			}
 		},
 		"plur": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
-			"integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
+			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
 			"dev": true,
 			"requires": {
 				"irregular-plurals": "^2.0.0"
@@ -6156,9 +5749,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.16.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-			"integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+			"integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -6230,6 +5823,16 @@
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
 			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
 			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -6370,9 +5973,9 @@
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
+			"integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0"
@@ -6389,15 +5992,10 @@
 			}
 		},
 		"regexp-tree": {
-			"version": "0.0.86",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.0.86.tgz",
-			"integrity": "sha512-xjTX9GmRw7Nn2wxinLoqQXv9Dt5yerP7CJIsYe/5z5gFs0Ltu20wRuZophafi9sf0JpsdVtki5EuICRYpgB1AQ==",
-			"dev": true,
-			"requires": {
-				"cli-table3": "^0.5.0",
-				"colors": "^1.1.2",
-				"yargs": "^10.0.3"
-			}
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.6.tgz",
+			"integrity": "sha512-LFrA98Dw/heXqDojz7qKFdygZmFoiVlvE1Zp7Cq2cvF+ZA+03Gmhy0k0PQlsC1jvHPiTUSs+pDHEuSWv6+6D7w==",
+			"dev": true
 		},
 		"regexpp": {
 			"version": "2.0.1",
@@ -6406,23 +6004,23 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
-			"integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^7.0.0",
+				"regenerate-unicode-properties": "^8.0.2",
 				"regjsgen": "^0.5.0",
 				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.0.2"
+				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
 		},
 		"registry-auth-token": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+			"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
 			"dev": true,
 			"requires": {
 				"rc": "^1.1.6",
@@ -6522,9 +6120,9 @@
 			"dev": true
 		},
 		"require-main-filename": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
 		"require-precompiled": {
@@ -6534,9 +6132,9 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+			"integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
@@ -6598,9 +6196,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-			"integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
+			"integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -6628,9 +6226,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+			"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
 		},
 		"semver-diff": {
 			"version": "2.1.0",
@@ -6639,6 +6237,14 @@
 			"dev": true,
 			"requires": {
 				"semver": "^5.0.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"serialize-error": {
@@ -6697,17 +6303,17 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sinon": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.3.tgz",
-			"integrity": "sha512-i6j7sqcLEqTYqUcMV327waI745VASvYuSuQMCjbAwlpAeuCgKZ3LtrjDxAbu+GjNQR0FEDpywtwGCIh8GicNyg==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+			"integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^1.3.0",
-				"@sinonjs/formatio": "^3.1.0",
-				"@sinonjs/samsam": "^3.0.2",
+				"@sinonjs/commons": "^1.4.0",
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/samsam": "^3.3.1",
 				"diff": "^3.5.0",
-				"lolex": "^3.0.0",
-				"nise": "^1.4.8",
+				"lolex": "^4.0.1",
+				"nise": "^1.4.10",
 				"supports-color": "^5.5.0"
 			},
 			"dependencies": {
@@ -6894,9 +6500,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.10",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-			"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+			"version": "0.5.12",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -6916,6 +6522,20 @@
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
+		},
+		"spawn-wrap": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+			"integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+			"dev": true,
+			"requires": {
+				"foreground-child": "^1.5.6",
+				"mkdirp": "^0.5.0",
+				"os-homedir": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.2",
+				"which": "^1.3.0"
+			}
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
@@ -6944,9 +6564,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
 			"dev": true
 		},
 		"split-string": {
@@ -7039,18 +6659,18 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-			"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^4.0.0"
+				"ansi-regex": "^4.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				}
 			}
@@ -7186,14 +6806,14 @@
 					}
 				},
 				"string-width": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-					"integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.0.0"
+						"strip-ansi": "^5.1.0"
 					}
 				}
 			}
@@ -7207,11 +6827,29 @@
 				"execa": "^0.7.0"
 			}
 		},
-		"text-encoding": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-			"dev": true
+		"test-exclude": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^2.0.0"
+			},
+			"dependencies": {
+				"read-pkg-up": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				}
+			}
 		},
 		"text-table": {
 			"version": "0.2.0",
@@ -7372,6 +7010,31 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
+		"type-fest": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+			"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+		},
+		"uglify-js": {
+			"version": "3.5.11",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
+			"integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.20.0",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"uid2": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
@@ -7395,15 +7058,15 @@
 			}
 		},
 		"unicode-match-property-value-ecmascript": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
 			"dev": true
 		},
 		"unicode-property-aliases-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
 			"dev": true
 		},
 		"union-value": {
@@ -7508,9 +7171,9 @@
 			"dev": true
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
 			"dev": true
 		},
 		"update-notifier": {
@@ -7651,9 +7314,9 @@
 			}
 		},
 		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
 			"dev": true
 		},
 		"wrap-ansi": {
@@ -7815,14 +7478,24 @@
 				"xo-init": "^0.7.0"
 			},
 			"dependencies": {
-				"globby": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-9.0.0.tgz",
-					"integrity": "sha512-q0qiO/p1w/yJ0hk8V9x1UXlgsXUxlGd0AHUOXZVXBO6aznDtpx7M8D1kBrCAItoPm+4l8r6ATXV1JpjY2SBQOw==",
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"globby": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+					"dev": true,
+					"requires": {
+						"@types/glob": "^7.1.1",
 						"array-union": "^1.0.2",
-						"dir-glob": "^2.2.1",
+						"dir-glob": "^2.2.2",
 						"fast-glob": "^2.2.6",
 						"glob": "^7.1.3",
 						"ignore": "^4.0.3",
@@ -7836,10 +7509,60 @@
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 					"dev": true
 				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"pkg-conf": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+					"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"load-json-file": "^4.0.0"
+					}
+				},
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				}
 			}
@@ -7884,9 +7607,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
 		},
 		"yallist": {
@@ -7896,75 +7619,49 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+			"integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
 			"dev": true,
 			"requires": {
 				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"os-locale": "^3.1.0",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^3.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^8.1.0"
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
-				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
+					"integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"repository": "istanbuljs/caching-transform",
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && nyc ava"
@@ -23,18 +23,18 @@
 		"hash"
 	],
 	"dependencies": {
-		"hasha": "^3.0.0",
-		"make-dir": "^2.0.0",
-		"package-hash": "^3.0.0",
+		"hasha": "^5.0.0",
+		"make-dir": "^3.0.0",
+		"package-hash": "^4.0.0",
 		"write-file-atomic": "^2.4.2"
 	},
 	"devDependencies": {
-		"ava": "^1.2.1",
-		"coveralls": "^3.0.2",
-		"nyc": "^13.3.0",
+		"ava": "^1.4.1",
+		"coveralls": "^3.0.3",
+		"nyc": "^14.1.0",
 		"proxyquire": "^2.1.0",
 		"rimraf": "^2.6.3",
-		"sinon": "^7.2.3",
+		"sinon": "^7.3.2",
 		"xo": "^0.24.0"
 	},
 	"nyc": {

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,18 @@ function hashData(input, metadata) {
 
 (Note that `metadata` is not taken into account otherwise.)
 
+##### filenamePrefix
+
+Type: `Function(metadata: *): string`
+
+Provide a filename to prefix the cache entry.  The return value may not contain any path separators.
+
+```js
+function filenamePrefix(metadata) {
+	return path.parse(metadata.filename || '').name + '-';
+}
+```
+
 ##### onHash
 
 Type: `Function(input: string|Buffer, metadata: *, hash: string)`

--- a/test.js
+++ b/test.js
@@ -405,3 +405,16 @@ test('salt can be a buffer', t => {
 
 	t.is(transform('foo'), 'foo bar');
 });
+
+test('filenamePrefix uses metadata to prefix filename', t => {
+	const transform = wrap({
+		transform: () => t.fail(),
+		filenamePrefix: metadata => path.parse(metadata.filename || '').name + '-'
+	});
+
+	makeDir.sync(transform.cacheDir);
+	const filename = path.join(transform.cacheDir, 'source-' + hasha([PKG_HASH, 'foo'], {algorithm: 'sha256'}));
+	fs.writeFileSync(filename, 'foo bar');
+
+	t.is(transform('foo', {filename: path.join(__dirname, 'source.js')}), 'foo bar');
+});


### PR DESCRIPTION
Fixes #4 

---

I'm open to suggestions for a different name to `filenamePrefix`.