### PR TITLE
Work around write-file-atomic Windows EPERM issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function wrap(opts) {
 		while (true) {
 			try {
 				return fs.readFileSync(cachedPath, encoding);
-			} catch (error) {
+			} catch (readError) {
 				if (!result) {
 					result = transform(input, metadata, hash);
 				}


### PR DESCRIPTION
Fixes #14

---

Going to wait for more feedback from @ehmicky to verify this resolves the issue before I consider merging.  Just posting the PR so it becomes visible to others in case someone objects to using a retry cycle.  My thinking is that caching-transform success implies that the cache file has been successfully created.